### PR TITLE
Rombak logika honor: HonorService, tahun anggaran, nominal rupiah per…

### DIFF
--- a/app/Http/Controllers/Admin/TimController.php
+++ b/app/Http/Controllers/Admin/TimController.php
@@ -4,10 +4,12 @@ namespace App\Http\Controllers\Admin;
 
 use App\Models\Tim;
 use App\Models\User;
+use App\Services\HonorService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 
 class TimController extends Controller
 {
@@ -34,7 +36,7 @@ class TimController extends Controller
 
     public function create()
     {
-        $users = User::all();
+        $users = User::with('jabatan')->orderBy('name')->get();
         return view('admin.tims.create', compact('users'));
     }
 
@@ -44,106 +46,147 @@ class TimController extends Controller
             'nama_tim'   => 'required|string|max:255',
             'keterangan' => 'nullable|string',
             'sk_file'    => 'required|file|mimes:pdf|max:2048',
-            'status'     => 'required|string',
-            'anggota'    => 'required|array',
+            'tahun'      => 'required|integer|min:2000|max:2100',
+            'anggota'    => 'required|array|min:1',
             'anggota.*'  => 'exists:users,id',
+            'nominal'    => 'array',
+            'nominal.*'  => 'nullable|numeric|min:0',
         ]);
 
-        // Handle upload file SK
-        if ($request->hasFile('sk_file')) {
-            $file = $request->file('sk_file');
-            $filename = time() . '_' . $file->getClientOriginalName();
-            $path = $file->storeAs('sk', $filename, 'public');
-            $validated['sk_file'] = $path;
+        $skPath = $request->file('sk_file')->store('sk_files', 'public');
+        $nominals = $request->input('nominal', []);
+
+        try {
+            DB::beginTransaction();
+
+            $tim = Tim::create([
+                'nama_tim'   => $validated['nama_tim'],
+                'keterangan' => $validated['keterangan'] ?? '',
+                'sk_file'    => $skPath,
+                'tahun'      => $validated['tahun'],
+                'created_by' => Auth::id(),
+                'status'     => 'pending',
+            ]);
+
+            $tim->users()->attach($this->pivotData($validated['anggota'], $nominals));
+
+            DB::commit();
+
+            return redirect()->route('admin.tims.index')->with('success', 'Tim berhasil ditambahkan');
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            Storage::disk('public')->delete($skPath);
+            return back()->withInput()->with('error', 'Gagal menambahkan tim.');
         }
-
-        $validated['created_by'] = Auth::id();
-
-        $tim = Tim::create($validated);
-
-        $tim->anggota()->sync($request->anggota);
-
-        return redirect()->route('admin.tims.index')
-            ->with('success', 'Tim berhasil ditambahkan');
     }
-
 
     public function show(Tim $tim)
     {
-        $tim->load('anggota', 'creator');
+        $tim->load('anggota.jabatan.eselon', 'creator');
         return view('admin.tims.show', compact('tim'));
     }
 
     public function edit(Tim $tim)
     {
-        $users = User::all();
-        $tim->load('anggota');
+        $users = User::with('jabatan')->orderBy('name')->get();
+        $tim->load('users');
         return view('admin.tims.edit', compact('tim', 'users'));
     }
 
     public function update(Request $request, Tim $tim)
     {
-        $data = $request->validate([
-            'nama_tim' => 'required|string|max:255',
+        $validated = $request->validate([
+            'nama_tim'   => 'required|string|max:255',
             'keterangan' => 'required|string',
-            'sk_file' => 'nullable|file|mimes:pdf',
-            'anggota' => 'required|array',
-            'anggota.*' => 'exists:users,id',
+            'sk_file'    => 'nullable|file|mimes:pdf|max:2048',
+            'tahun'      => 'required|integer|min:2000|max:2100',
+            'anggota'    => 'required|array|min:1',
+            'anggota.*'  => 'exists:users,id',
+            'nominal'    => 'array',
+            'nominal.*'  => 'nullable|numeric|min:0',
         ]);
 
+        $data = [
+            'nama_tim'   => $validated['nama_tim'],
+            'keterangan' => $validated['keterangan'],
+            'tahun'      => $validated['tahun'],
+        ];
+
         if ($request->hasFile('sk_file')) {
-            $file = $request->file('sk_file')->store('sk_files');
-            $data['sk_file'] = $file;
+            $old = $tim->sk_file;
+            $data['sk_file'] = $request->file('sk_file')->store('sk_files', 'public');
         }
 
-        $tim->update($data);
+        DB::transaction(function () use ($tim, $data, $validated, $request, &$old) {
+            $tim->update($data);
+            // sync TANPA menghilangkan data pivot (jabatan & nominal_honor)
+            $tim->users()->sync($this->pivotData($validated['anggota'], $request->input('nominal', [])));
+        });
 
-        // Sync anggota tim
-        $tim->users()->sync($request->anggota);
+        if (isset($old) && $old) {
+            Storage::disk('public')->delete($old);
+        }
 
         return redirect()->route('admin.tims.index')->with('success', 'Tim berhasil diperbarui!');
     }
 
-
     public function destroy(Tim $tim)
     {
+        Storage::disk('public')->delete($tim->sk_file);
         $tim->delete();
         return redirect()->route('admin.tims.index')->with('success', 'Tim berhasil dihapus');
     }
 
+    /**
+     * Bangun payload pivot [user_id => ['jabatan'=>..., 'nominal_honor'=>...]].
+     */
+    private function pivotData(array $anggotaIds, array $nominals): array
+    {
+        return User::with('jabatan')
+            ->whereIn('id', $anggotaIds)
+            ->get()
+            ->mapWithKeys(fn($u) => [$u->id => [
+                'jabatan'       => $u->jabatan->name ?? null,
+                'nominal_honor' => (int) ($nominals[$u->id] ?? 0),
+            ]])
+            ->all();
+    }
 
     /** =========================
      *  ACTION APPROVE / REJECT
      *  ========================= */
-    public function checkMemberStatus(Tim $tim)
+    public function checkMemberStatus(Tim $tim, HonorService $honor)
     {
-        $memberStatus = $tim->anggota()->with('jabatan.eselon')->get()->map(function ($user) {
-            $currentApprovedCount = $user->tims()
-                ->where('status', 'approved')
-                ->count();
+        $tim->load('users.jabatan.eselon');
 
-            $maxHonor = $user->jabatan->eselon->maks_honor ?? 0;
-            $remaining = max(0, $maxHonor - $currentApprovedCount);
+        $members = $tim->users->map(function ($user) use ($tim, $honor) {
+            $ringkasan = $honor->ringkasan($user, (int) $tim->tahun);
+            $s = $honor->statusUntukTim($user, $tim->id, (int) $tim->tahun);
+
+            $akanDibayar = $s && in_array($s['status'], [HonorService::DIBAYAR, HonorService::PREDIKSI_DIBAYAR]);
+            $maks = $ringkasan['maks_honor'];
 
             return [
-                'id' => $user->id,
-                'name' => $user->name,
-                'nip' => $user->nip,
-                'jabatan' => $user->jabatan->name,
-                'current_count' => $currentApprovedCount,
-                'max_honor' => $maxHonor,
-                'remaining' => $remaining,
-                'status' => $currentApprovedCount >= $maxHonor ? 'over_limit' : ($remaining <= 1 ? 'warning' : 'safe'),
-                'percentage' => $maxHonor > 0 ? ($currentApprovedCount / $maxHonor) * 100 : 0
+                'id'            => $user->id,
+                'name'          => $user->name,
+                'nip'           => $user->nip,
+                'jabatan'       => $user->jabatan->name,
+                'current_count' => $ringkasan['jumlah_tim_approved'],
+                'max_honor'     => $maks,
+                'remaining'     => $ringkasan['sisa_slot'],
+                'nominal'       => $s['nominal'] ?? 0,
+                'status'        => !$akanDibayar ? 'over_limit' : ($ringkasan['sisa_slot'] <= 1 ? 'warning' : 'safe'),
+                'percentage'    => $maks > 0 ? min(100, ($ringkasan['jumlah_tim_approved'] / $maks) * 100) : 0,
             ];
         });
 
         return response()->json([
-            'members' => $memberStatus,
-            'has_over_limit' => $memberStatus->contains('status', 'over_limit'),
-            'has_warning' => $memberStatus->contains('status', 'warning')
+            'members'        => $members,
+            'has_over_limit' => $members->contains('status', 'over_limit'),
+            'has_warning'    => $members->contains('status', 'warning'),
         ]);
     }
+
     public function approve(Tim $tim)
     {
         $tim->update(['status' => 'approved']);
@@ -154,7 +197,6 @@ class TimController extends Controller
 
         return redirect()->route('admin.tims.index')->with('success', 'Tim berhasil di-approve.');
     }
-
 
     public function reject(Tim $tim)
     {

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -46,7 +46,7 @@ class UserController extends Controller
             'password' => 'required|string|min:6|confirmed',
         ]);
 
-        User::create([
+        $user = User::create([
             'nip'      => $request->nip,
             'name'     => $request->name,
             'email'    => $request->email,
@@ -55,15 +55,21 @@ class UserController extends Controller
             'password' => Hash::make($request->password),
         ]);
 
+        $user->jabatanHistories()->create([
+            'jabatan_id'    => $user->jabatan_id,
+            'tanggal_mulai' => now(),
+        ]);
+
         return redirect()->route('admin.users.index')->with('success', 'User berhasil ditambahkan.');
     }
 
-    public function show(User $user)
+    public function show(User $user, \App\Services\HonorService $honor)
     {
-        $user->load('jabatan.eselon'); // pastikan relasi sudah dibuat
-        $maksHonor = $user->jabatan->eselon->maks_honor ?? 0;
-        $totalTim = $user->tims()->where('status', 'approved')->count();
-        return view('admin.users.show', compact('user', 'maksHonor', 'totalTim'));
+        $user->load('jabatan.eselon');
+        $ringkasan = $honor->ringkasan($user);
+        $maksHonor = $ringkasan['maks_honor'];
+        $totalTim  = $ringkasan['jumlah_dibayar'];
+        return view('admin.users.show', compact('user', 'maksHonor', 'totalTim', 'ringkasan'));
     }
 
 
@@ -89,7 +95,20 @@ class UserController extends Controller
             $data['password'] = Hash::make($request->password);
         }
 
+        $jabatanLama = $user->jabatan_id;
         $user->update($data);
+
+        // Catat mutasi/promosi bila jabatan berubah
+        if ((int) $data['jabatan_id'] !== (int) $jabatanLama) {
+            $user->jabatanHistories()
+                ->whereNull('tanggal_selesai')
+                ->update(['tanggal_selesai' => now()]);
+
+            $user->jabatanHistories()->create([
+                'jabatan_id'    => $user->jabatan_id,
+                'tanggal_mulai' => now(),
+            ]);
+        }
 
         return redirect()->route('admin.users.index')->with('success', 'User berhasil diperbarui.');
     }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,8 +4,6 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
-use App\Models\User;
 
 class AuthController extends Controller
 {
@@ -21,39 +19,19 @@ class AuthController extends Controller
             'password' => 'required|string',
         ]);
 
-        $latestBatch = User::max('batch');
-        $remember = $request->has('remember'); // ambil nilai checkbox remember
+        $remember = $request->boolean('remember');
 
-        // Cari user dengan NIP yang sesuai di batch terbaru
-        $user = User::where('nip', $request->nip)
-            ->where('batch', $latestBatch)
-            ->first();
-
-        // Coba login dengan remember me
-        if (!$user || !Auth::attempt([
-            'nip' => $request->nip,
-            'password' => $request->password,
-            'batch' => $latestBatch
-        ], $remember)) { // passing remember ke attempt()
+        if (!Auth::attempt(['nip' => $request->nip, 'password' => $request->password], $remember)) {
             return back()->withErrors([
-                'login' => 'NIP atau password salah, atau akun Anda bukan dari batch terbaru.'
+                'login' => 'NIP atau password salah.',
             ])->withInput($request->only('nip'));
         }
 
-        // Regenerate session untuk keamanan
         $request->session()->regenerate();
 
-        // Set cookie remember me jika dicentang
-        if ($remember) {
-            // Cookie akan bertahan 30 hari
-            cookie()->queue('remember_web', encrypt($user->id), 43200);
-        }
-
-        if ($user->role === 'admin') {
-            return redirect()->intended(route('admin.dashboard'));
-        }
-
-        return redirect()->intended(route('staff.dashboard.index'));
+        return Auth::user()->role === 'admin'
+            ? redirect()->intended(route('admin.dashboard'))
+            : redirect()->intended(route('staff.dashboard.index'));
     }
 
     public function logout(Request $request)

--- a/app/Http/Controllers/EselonController.php
+++ b/app/Http/Controllers/EselonController.php
@@ -7,59 +7,54 @@ use Illuminate\Http\Request;
 
 class EselonController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
     public function index()
     {
-        //
+        $eselons = Eselon::withCount('jabatans')->orderBy('name')->get();
+        return view('admin.eselons.index', compact('eselons'));
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
     public function create()
     {
-        //
+        return view('admin.eselons.create');
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store(Request $request)
     {
-        //
+        $data = $request->validate([
+            'name'       => 'required|string|max:255|unique:eselons,name',
+            'maks_honor' => 'required|integer|min:0|max:255',
+        ]);
+
+        Eselon::create($data);
+
+        return redirect()->route('admin.eselons.index')->with('success', 'Eselon berhasil ditambahkan.');
     }
 
-    /**
-     * Display the specified resource.
-     */
-    public function show(Eselon $eselon)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
     public function edit(Eselon $eselon)
     {
-        //
+        return view('admin.eselons.edit', compact('eselon'));
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
     public function update(Request $request, Eselon $eselon)
     {
-        //
+        $data = $request->validate([
+            'name'       => 'required|string|max:255|unique:eselons,name,' . $eselon->id,
+            'maks_honor' => 'required|integer|min:0|max:255',
+        ]);
+
+        $eselon->update($data);
+
+        return redirect()->route('admin.eselons.index')->with('success', 'Eselon berhasil diperbarui.');
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy(Eselon $eselon)
     {
-        //
+        if ($eselon->jabatans()->exists()) {
+            return back()->with('error', 'Eselon tidak bisa dihapus karena masih dipakai jabatan.');
+        }
+
+        $eselon->delete();
+
+        return back()->with('success', 'Eselon berhasil dihapus.');
     }
 }

--- a/app/Http/Controllers/JabatanController.php
+++ b/app/Http/Controllers/JabatanController.php
@@ -2,64 +2,62 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Eselon;
 use App\Models\Jabatan;
 use Illuminate\Http\Request;
 
 class JabatanController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
     public function index()
     {
-        //
+        $jabatans = Jabatan::with('eselon')->withCount('users')->orderBy('name')->get();
+        return view('admin.jabatans.index', compact('jabatans'));
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
     public function create()
     {
-        //
+        $eselons = Eselon::orderBy('name')->get();
+        return view('admin.jabatans.create', compact('eselons'));
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store(Request $request)
     {
-        //
+        $data = $request->validate([
+            'name'      => 'required|string|max:255',
+            'eselon_id' => 'required|exists:eselons,id',
+        ]);
+
+        Jabatan::create($data);
+
+        return redirect()->route('admin.jabatans.index')->with('success', 'Jabatan berhasil ditambahkan.');
     }
 
-    /**
-     * Display the specified resource.
-     */
-    public function show(Jabatan $jabatan)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
     public function edit(Jabatan $jabatan)
     {
-        //
+        $eselons = Eselon::orderBy('name')->get();
+        return view('admin.jabatans.edit', compact('jabatan', 'eselons'));
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
     public function update(Request $request, Jabatan $jabatan)
     {
-        //
+        $data = $request->validate([
+            'name'      => 'required|string|max:255',
+            'eselon_id' => 'required|exists:eselons,id',
+        ]);
+
+        $jabatan->update($data);
+
+        return redirect()->route('admin.jabatans.index')->with('success', 'Jabatan berhasil diperbarui.');
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy(Jabatan $jabatan)
     {
-        //
+        if ($jabatan->users()->exists()) {
+            return back()->with('error', 'Jabatan tidak bisa dihapus karena masih dipakai ASN.');
+        }
+
+        $jabatan->delete();
+
+        return back()->with('success', 'Jabatan berhasil dihapus.');
     }
 }

--- a/app/Http/Controllers/StaffController.php
+++ b/app/Http/Controllers/StaffController.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Tim;
+use App\Models\User;
+use App\Services\HonorService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -11,349 +14,199 @@ use Illuminate\Validation\ValidationException;
 class StaffController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Map status HonorService -> label lama yang dipakai blade.
      */
-    public function indexDashboard()
+    private array $legacyLabel = [
+        HonorService::DIBAYAR                => 'Honor Diterima',
+        HonorService::TIDAK_DIBAYAR          => 'Tidak menerima honor lagi',
+        HonorService::PREDIKSI_DIBAYAR       => 'Akan menerima honor jika disetujui',
+        HonorService::PREDIKSI_TIDAK_DIBAYAR => 'Tidak akan menerima honor',
+    ];
+
+    /**
+     * Bangun peta status honor per (anggota, tim) untuk sekumpulan tim.
+     * Menghitung per tahun anggaran masing-masing tim, dengan cache per (anggota, tahun).
+     *
+     * @return array{0: array<int,array<int,string>>, 1: array<int,int>}  [statusHonorPerTim, timCountPerUser(tahun berjalan)]
+     */
+    private function buildStatusMap($tims, HonorService $honor): array
     {
-        $latestBatch = \App\Models\User::max('batch');
-        $user = Auth::user();
+        $cache = [];
+        $resolve = function (User $asn, int $tahun) use (&$cache, $honor) {
+            return $cache[$asn->id][$tahun] ??= $honor->statusPerTim($asn, $tahun);
+        };
+
+        $statusHonorPerTim = [];
+        foreach ($tims as $tim) {
+            foreach ($tim->users as $anggota) {
+                $s = $resolve($anggota, (int) $tim->tahun)->get($tim->id);
+                if ($s) {
+                    $statusHonorPerTim[$anggota->id][$tim->id] = $this->legacyLabel[$s['status']] ?? $s['status'];
+                }
+            }
+        }
+
+        // Jumlah tim DIBAYAR tahun berjalan per anggota (untuk tampilan "x/maks")
+        $currentYear = $honor->tahunBerjalan();
+        $timCountPerUser = [];
+        foreach ($tims->flatMap->users->unique('id') as $anggota) {
+            $timCountPerUser[$anggota->id] = $resolve($anggota, $currentYear)
+                ->where('status', HonorService::DIBAYAR)->count();
+        }
+
+        return [$statusHonorPerTim, $timCountPerUser];
+    }
+
+    public function indexDashboard(HonorService $honor)
+    {
+        $user = Auth::user()->load('jabatan.eselon');
 
         $tims = $user->tims()
-            ->with(['users' => function ($q) use ($latestBatch) {
-                $q->where('batch', $latestBatch)
-                    ->with(['jabatan.eselon', 'tims']);
-            }])
+            ->with(['users.jabatan.eselon'])
             ->latest()
             ->get();
 
-        // Hitung tim yang dapat honor (prioritas tim terbaru)
-        $timApproveIds = $user->tims()
-            ->where('tims.status', 'approved')
-            ->orderBy('tims.created_at', 'desc')  // Tim baru dulu yang dapat honor
-            ->limit($user->jabatan->eselon->maks_honor ?? 0)
-            ->pluck('tims.id');
+        [$statusHonorPerTim, $timCountPerUser] = $this->buildStatusMap($tims, $honor);
 
-        $totalTim = $timApproveIds->count();
-        $maksHonor = $user->jabatan->eselon->maks_honor ?? 0;
-
-        // Hitung data untuk setiap anggota
-        $timCountPerUser = [];
-        $terimaHonorPerUser = [];
-        $statusHonorPerUser = []; // Array baru untuk status honor per tim per user
-        $statusHonorPerTim = []; // LOGIC BARU: Status honor per tim untuk setiap user
-
-        foreach ($tims->flatMap->users as $anggota) {
-            // Tim yang dapat honor (limit sesuai maks_honor, prioritas terbaru)
-            $timApproveIdsAnggota = $anggota->tims()
-                ->where('tims.status', 'approved')
-                ->orderBy('tims.created_at', 'desc')  // Tim baru dulu
-                ->limit($anggota->jabatan->eselon->maks_honor)
-                ->pluck('tims.id');
-
-            // Jumlah tim approved SEMUA (tanpa limit) untuk logic pesan
-            $totalTimApproved = $anggota->tims()
-                ->where('tims.status', 'approved')
-                ->count();
-
-            // LOGIC BARU: Hitung status honor untuk setiap tim berdasarkan updated_at tercepat
-            // Ambil tim approved yang sudah ada
-            $timsApprovedSorted = $anggota->tims()
-                ->where('tims.status', 'approved')
-                ->orderBy('tims.updated_at', 'asc') // Tim dengan updated_at tercepat dulu (yang dapat honor)
-                ->get();
-
-            // Ambil tim pending untuk prediksi
-            $timsPendingSorted = $anggota->tims()
-                ->where('tims.status', 'pending')
-                ->orderBy('tims.created_at', 'asc') // Tim pending diurutkan berdasarkan created_at
-                ->get();
-
-            $statusHonorPerUser[$anggota->id] = [];
-            $maksHonorAnggota = $anggota->jabatan->eselon->maks_honor;
-
-            // LOGIC KHUSUS: Tentukan status honor per tim APPROVED
-            foreach ($timsApprovedSorted as $index => $timApproved) {
-                if ($index < $maksHonorAnggota) {
-                    // Tim ini mendapat honor (urutan 1 sampai maks_honor berdasarkan updated_at tercepat)
-                    $statusHonorPerUser[$anggota->id][$timApproved->id] = 'honor_diterima';
-                    $statusHonorPerTim[$anggota->id][$timApproved->id] = 'Honor Diterima';
-                } else {
-                    // Tim ini tidak mendapat honor (sudah melebihi maks_honor)
-                    $statusHonorPerUser[$anggota->id][$timApproved->id] = 'tidak_honor';
-                    $statusHonorPerTim[$anggota->id][$timApproved->id] = 'Tidak menerima honor lagi';
-                }
-            }
-
-            // LOGIC KHUSUS: Tentukan prediksi status honor untuk tim PENDING
-            $currentApprovedCount = $timsApprovedSorted->count();
-            foreach ($timsPendingSorted as $index => $timPending) {
-                $posisiJikaApproved = $currentApprovedCount + $index; // Posisi jika tim ini di-approve
-
-                if ($posisiJikaApproved < $maksHonorAnggota) {
-                    // Tim pending ini akan mendapat honor jika di-approve
-                    $statusHonorPerUser[$anggota->id][$timPending->id] = 'prediksi_honor_diterima';
-                    $statusHonorPerTim[$anggota->id][$timPending->id] = 'Akan menerima honor jika disetujui';
-                } else {
-                    // Tim pending ini tidak akan mendapat honor jika di-approve
-                    $statusHonorPerUser[$anggota->id][$timPending->id] = 'prediksi_tidak_honor';
-                    $statusHonorPerTim[$anggota->id][$timPending->id] = 'Tidak akan menerima honor';
-                }
-            }
-
-            $timCountPerUser[$anggota->id] = $timApproveIdsAnggota->count();
-            $terimaHonorPerUser[$anggota->id] = $totalTimApproved;
-        }
+        $ringkasanDiri = $honor->ringkasan($user);
+        $maksHonor = $ringkasanDiri['maks_honor'];
+        $totalTim  = $ringkasanDiri['jumlah_dibayar']; // honor diterima tahun berjalan
 
         return view('staff.index', compact(
             'user',
             'tims',
             'totalTim',
             'maksHonor',
+            'ringkasanDiri',
             'timCountPerUser',
-            'terimaHonorPerUser',
-            'statusHonorPerUser',
-            'statusHonorPerTim' // Pass variable baru untuk status honor per tim
+            'statusHonorPerTim'
         ));
     }
 
-    public function indexTim(Request $request)
+    public function indexProfile(HonorService $honor)
     {
-        $user = Auth::user();
-        $selectedBatch = $request->batch ?: $user->batch;
+        $user = Auth::user()->load('jabatan.eselon');
+        $ringkasan = $honor->ringkasan($user);
 
-        // Ambil semua user dengan NIP yang sama
-        $userIds = \App\Models\User::where('nip', $user->nip)
-            ->pluck('id');
+        return view('staff.profile', compact('user', 'ringkasan'));
+    }
 
-        // Ambil tim berdasarkan user_id yang memiliki NIP sama
-        $tims = \App\Models\Tim::whereHas('users', function ($query) use ($userIds) {
-            $query->whereIn('users.id', $userIds);
-        })
-            ->with(['users' => function ($query) use ($selectedBatch) {
-                $query->when($selectedBatch, function ($q) use ($selectedBatch) {
-                    $q->where('batch', $selectedBatch);
-                })
-                    ->with(['jabatan.eselon']);
-            }])
+    public function indexTim(Request $request, HonorService $honor)
+    {
+        $user = Auth::user()->load('jabatan.eselon');
+
+        $tahunList = $user->tims()
+            ->distinct()
+            ->orderByDesc('tims.tahun')
+            ->pluck('tims.tahun');
+
+        if ($tahunList->isEmpty()) {
+            $tahunList = collect([$honor->tahunBerjalan()]);
+        }
+
+        $tahun = (int) ($request->tahun ?: $tahunList->first());
+
+        $tims = $user->tims()
+            ->where('tims.tahun', $tahun)
+            ->with(['users.jabatan.eselon'])
             ->latest()
             ->get();
 
-        // Ambil semua user yang ada di tim untuk menghitung approved count mereka
-        $allUserIdsInTims = $tims->flatMap->users->pluck('id')->unique();
+        [$statusHonorPerTim] = $this->buildStatusMap($tims, $honor);
 
-        // Hitung jumlah tim approved untuk setiap user dengan limit maks_honor (sama seperti createTim)
-        $approvedTimCount = [];
-        $statusHonorPerTim = []; // Inisialisasi array untuk status honor per tim
+        $ringkasan = $honor->ringkasan($user, $tahun);
+        $maksHonor = $ringkasan['maks_honor'];
+        $approvedTimCount = [$user->id => $ringkasan['jumlah_dibayar']];
+        $progress = $maksHonor > 0 ? min(100, ($ringkasan['jumlah_dibayar'] / $maksHonor) * 100) : 0;
 
-        foreach ($allUserIdsInTims as $userId) {
-            $userModel = \App\Models\User::find($userId);
-            $maksHonorAnggota = $userModel->jabatan->eselon->maks_honor ?? 0;
-
-            // Ambil tim approved yang sudah ada, diurutkan berdasarkan updated_at (tercepat dulu)
-            $timsApprovedSorted = $userModel->tims()
-                ->where('tims.status', 'approved')
-                ->orderBy('tims.updated_at', 'asc')
-                ->get();
-
-            // Hitung actual tim count dengan urutan updated_at ASC
-            $actualTimCount = $timsApprovedSorted->count();
-
-            // Tampilkan maksimal sesuai maks_honor
-            $approvedTimCount[$userId] = min($actualTimCount, $maksHonorAnggota);
-
-            // Tentukan status honor untuk setiap tim approved
-            foreach ($timsApprovedSorted as $index => $timApproved) {
-                if ($index < $maksHonorAnggota) {
-                    $statusHonorPerTim[$userId][$timApproved->id] = 'Honor Diterima';
-                } else {
-                    $statusHonorPerTim[$userId][$timApproved->id] = 'Tidak menerima honor lagi';
-                }
-            }
-
-            // Ambil tim pending untuk prediksi
-            $timsPendingSorted = $userModel->tims()
-                ->where('tims.status', 'pending')
-                ->orderBy('tims.created_at', 'asc') // Tim pending diurutkan berdasarkan created_at
-                ->get();
-
-            $currentApprovedCount = $timsApprovedSorted->count();
-            foreach ($timsPendingSorted as $index => $timPending) {
-                $posisiJikaApproved = $currentApprovedCount + $index;
-
-                if ($posisiJikaApproved < $maksHonorAnggota) {
-                    $statusHonorPerTim[$userId][$timPending->id] = 'Akan menerima honor jika disetujui';
-                } else {
-                    $statusHonorPerTim[$userId][$timPending->id] = 'Tidak akan menerima honor';
-                }
-            }
-        }
-
-        // Hitung progress (berdasarkan user yang login)
-        $maksHonor = $user->jabatan->eselon->maks_honor ?? 0;
-        $progress = $maksHonor > 0 ? ($approvedTimCount[$user->id] / $maksHonor) * 100 : 0;
-        $progress = min($progress, 100); // Maksimal 100%
-
-        // Ambil batch unik dari user dengan NIP yang sama
-        $batches = \App\Models\User::where('nip', $user->nip)
-            ->pluck('batch')
-            ->unique()
-            ->sortDesc()
-            ->values();
-
-        // Filter users dalam tim berdasarkan batch yang dipilih
-        $tims->each(function ($tim) use ($selectedBatch) {
-            $tim->setRelation('users', $tim->users->filter(function ($user) use ($selectedBatch) {
-                return $selectedBatch ? $user->batch == $selectedBatch : true;
-            }));
-        });
-
-        return view('staff.tim.index', compact('user', 'tims', 'selectedBatch', 'batches', 'approvedTimCount', 'maksHonor', 'progress', 'statusHonorPerTim'));
+        return view('staff.tim.index', compact(
+            'user',
+            'tims',
+            'tahun',
+            'tahunList',
+            'approvedTimCount',
+            'maksHonor',
+            'progress',
+            'statusHonorPerTim'
+        ));
     }
-    public function createTim()
-    {
-        $latestBatch = \App\Models\User::max('batch');
 
-        $availableUsers = \App\Models\User::where('batch', $latestBatch)
-            ->where('role', 'staff')
-            ->with(['jabatan' => function ($query) {
-                $query->with('eselon');
-            }])
+    public function createTim(HonorService $honor)
+    {
+        $availableUsers = User::where('role', 'staff')
+            ->with('jabatan.eselon')
+            ->orderBy('name')
             ->get();
 
+        $me = Auth::user()->load('jabatan.eselon');
+        if (!$availableUsers->contains('id', $me->id)) {
+            $availableUsers->push($me);
+        }
+
+        $currentYear = $honor->tahunBerjalan();
         $timCounts = [];
-        $statusHonorPerTim = []; // Variabel baru untuk menyimpan status honor per tim per user
-
-        // Pastikan user yang sedang login ada di availableUsers
-        $loggedInUser = Auth::user();
-        if (!$availableUsers->contains('id', $loggedInUser->id)) {
-            $availableUsers->push($loggedInUser);
+        foreach ($availableUsers as $u) {
+            $timCounts[$u->id] = $honor->ringkasan($u, $currentYear)['jumlah_dibayar'];
         }
 
-        foreach ($availableUsers as $user) {
-            $maksHonor = $user->jabatan->eselon->maks_honor ?? 0;
-
-            // Ambil semua tim approved yang diikuti user, urutkan berdasarkan updated_at (tercepat dulu)
-            $timsApprovedSorted = $user->tims()
-                ->where('status', 'approved')
-                ->orderBy('updated_at', 'asc') // Urutkan berdasarkan updated_at tercepat
-                ->get();
-
-            $currentHonorCount = 0; // Counter untuk tim yang menerima honor
-            $timCounts[$user->id] = 0; // Inisialisasi jumlah tim yang menerima honor
-
-            foreach ($timsApprovedSorted as $index => $timApproved) {
-                if ($currentHonorCount < $maksHonor) {
-                    // Tim ini mendapat honor
-                    $statusHonorPerTim[$user->id][$timApproved->id] = 'Honor Diterima';
-                    $currentHonorCount++;
-                } else {
-                    // Tim ini tidak mendapat honor lagi
-                    $statusHonorPerTim[$user->id][$timApproved->id] = 'Tidak menerima honor lagi';
-                }
-            }
-            // timCounts[$user->id] akan berisi jumlah tim yang benar-benar menerima honor
-            $timCounts[$user->id] = $currentHonorCount;
-
-            // Ambil tim pending untuk prediksi (logic ini sudah ada di indexTim, bisa disesuaikan jika perlu di createTim)
-            // Untuk createTim, kita hanya perlu tim approved yang sudah ada.
-            // Jika ingin menampilkan prediksi untuk tim pending di create.blade.php, logic ini perlu ditambahkan.
-            // Namun, untuk kebutuhan "jumlah tim yang statusnya approved" dan "honorarium" di create.blade.php,
-            // kita fokus pada tim yang sudah approved.
-        }
-
-        return view('staff.tim.create', compact('availableUsers', 'timCounts', 'statusHonorPerTim'));
+        return view('staff.tim.create', compact('availableUsers', 'timCounts'));
     }
 
-    public function storeTim(Request $request)
+    public function storeTim(Request $request, HonorService $honor)
     {
-        // Validasi input
         $validated = $request->validate([
-            'nama_tim' => 'required|string|max:255',
-            'keterangan' => 'required|string',
-            'sk_file' => 'required|file|mimes:pdf|max:2048', // maksimal 2MB
-            'anggota' => 'required|array|min:1',
-            'anggota.*' => 'exists:users,id',
+            'nama_tim'    => 'required|string|max:255',
+            'keterangan'  => 'required|string',
+            'sk_file'     => 'required|file|mimes:pdf|max:2048',
+            'anggota'     => 'required|array|min:1',
+            'anggota.*'   => 'exists:users,id',
+            'nominal'     => 'array',
+            'nominal.*'   => 'nullable|numeric|min:0',
         ]);
 
-        // Validasi kustom: Pastikan user yang sedang login selalu ada di array anggota
+        // Pembuat tim wajib jadi anggota
         if (!in_array(Auth::id(), $validated['anggota'])) {
             throw ValidationException::withMessages([
                 'anggota' => 'Anda harus menjadi bagian dari tim yang Anda buat.',
             ]);
         }
+        $validated['anggota'] = array_values(array_unique(array_merge($validated['anggota'], [Auth::id()])));
 
-        // Pastikan user yang sedang login selalu ada di array anggota, bahkan jika ada manipulasi frontend
-        $validated['anggota'] = array_unique(array_merge($validated['anggota'], [Auth::id()]));
-
-
-        // Cek anggota yang sudah mencapai batas honor (untuk informasi saja)
-        $overLimitUsers = \App\Models\User::whereIn('id', $validated['anggota'])
-            ->with(['jabatan.eselon'])
-            ->get()
-            ->filter(function ($user) {
-                // Ambil tim approved yang sudah ada, diurutkan berdasarkan updated_at (tercepat dulu)
-                $timsApprovedSorted = $user->tims()
-                    ->where('status', 'approved')
-                    ->orderBy('updated_at', 'asc')
-                    ->get();
-
-                $maksHonor = $user->jabatan->eselon->maks_honor ?? 0;
-                $currentHonorCount = 0;
-                foreach ($timsApprovedSorted as $timApproved) {
-                    if ($currentHonorCount < $maksHonor) {
-                        $currentHonorCount++;
-                    } else {
-                        break; // Sudah mencapai batas honor
-                    }
-                }
-                return $currentHonorCount >= $maksHonor;
-            });
-
-        $warningMessage = '';
-        if ($overLimitUsers->isNotEmpty()) {
-            $userNames = $overLimitUsers->pluck('name')->join(', ');
-            $warningMessage = " Catatan: $userNames sudah mencapai batas maksimal honor dan tidak akan menerima honor untuk tim ini.";
-        }
-
-        // Upload file SK
         $skPath = $request->file('sk_file')->store('sk_files', 'public');
+        $nominals = $request->input('nominal', []);
 
         try {
             DB::beginTransaction();
 
-            $tim = \App\Models\Tim::create([
-                'nama_tim' => $validated['nama_tim'],
+            $tim = Tim::create([
+                'nama_tim'   => $validated['nama_tim'],
                 'keterangan' => $validated['keterangan'],
-                'sk_file' => $skPath,
+                'sk_file'    => $skPath,
+                'tahun'      => $honor->tahunBerjalan(),
                 'created_by' => Auth::id(),
-                'status' => 'pending',
+                'status'     => 'pending',
             ]);
 
-            // Attach dengan jabatan dari user
-            $anggotaData = collect($validated['anggota'])->mapWithKeys(function ($userId) {
-                $user = \App\Models\User::find($userId);
-
-                return [$userId => ['jabatan' => $user->jabatan->name]];
+            $anggotaData = collect($validated['anggota'])->mapWithKeys(function ($userId) use ($nominals) {
+                $u = User::with('jabatan')->find($userId);
+                return [$userId => [
+                    'jabatan'       => $u->jabatan->name ?? null,
+                    'nominal_honor' => (int) ($nominals[$userId] ?? 0),
+                ]];
             });
 
-            $tim->users()->attach($anggotaData);
+            $tim->users()->attach($anggotaData->all());
 
             DB::commit();
 
-            $successMessage = 'Tim berhasil dibuat dan menunggu persetujuan admin.' . $warningMessage;
-
             return redirect()
                 ->route('staff.tim.index')
-                ->with('success', $successMessage);
-        } catch (\Exception $e) {
-            // Rollback jika terjadi error
+                ->with('success', 'Tim berhasil dibuat dan menunggu persetujuan admin.');
+        } catch (\Throwable $e) {
             DB::rollBack();
-
-            // Hapus file yang sudah diupload jika ada error
             if (isset($skPath)) {
                 Storage::disk('public')->delete($skPath);
             }
-
             return redirect()
                 ->back()
                 ->withInput()

--- a/app/Models/Eselon.php
+++ b/app/Models/Eselon.php
@@ -9,7 +9,12 @@ class Eselon extends Model
 {
     use HasFactory;
 
-    protected $guarded = [];
+    // maks_honor = jumlah maksimal tim yang DIBAYAR per tahun anggaran untuk ASN di eselon ini
+    protected $fillable = ['name', 'maks_honor'];
+
+    protected $casts = [
+        'maks_honor' => 'integer',
+    ];
 
     public function jabatans()
     {

--- a/app/Models/Jabatan.php
+++ b/app/Models/Jabatan.php
@@ -9,7 +9,7 @@ class Jabatan extends Model
 {
     use HasFactory;
 
-    protected $guarded = [];
+    protected $fillable = ['name', 'eselon_id'];
 
     public function eselon()
     {
@@ -19,5 +19,10 @@ class Jabatan extends Model
     public function users()
     {
         return $this->hasMany(User::class);
+    }
+
+    public function histories()
+    {
+        return $this->hasMany(JabatanHistory::class);
     }
 }

--- a/app/Models/JabatanHistory.php
+++ b/app/Models/JabatanHistory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class JabatanHistory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'jabatan_id', 'tanggal_mulai', 'tanggal_selesai'];
+
+    protected $casts = [
+        'tanggal_mulai' => 'date',
+        'tanggal_selesai' => 'date',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function jabatan()
+    {
+        return $this->belongsTo(Jabatan::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,7 +17,17 @@ class User extends Authenticatable
         'email',
         'jabatan_id',
         'role',
+        'status_akun',
         'password',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    protected $casts = [
+        'email_verified_at' => 'datetime',
     ];
 
     public function timsCreated()
@@ -27,11 +37,18 @@ class User extends Authenticatable
 
     public function tims()
     {
-        return $this->belongsToMany(Tim::class, 'tim_user')->withPivot('jabatan')->withTimestamps();
+        return $this->belongsToMany(Tim::class, 'tim_user')
+            ->withPivot('jabatan', 'nominal_honor')
+            ->withTimestamps();
     }
 
     public function jabatan()
     {
         return $this->belongsTo(Jabatan::class);
+    }
+
+    public function jabatanHistories()
+    {
+        return $this->hasMany(JabatanHistory::class);
     }
 }

--- a/app/Models/tim.php
+++ b/app/Models/tim.php
@@ -9,17 +9,23 @@ class Tim extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['nama_tim', 'keterangan', 'sk_file', 'created_by', 'status'];
+    protected $fillable = ['nama_tim', 'keterangan', 'sk_file', 'tahun', 'created_by', 'status'];
+
+    protected $casts = [
+        'tahun' => 'integer',
+    ];
 
     public function users()
     {
         return $this->belongsToMany(User::class, 'tim_user')
-            ->withPivot('jabatan')
+            ->withPivot('jabatan', 'nominal_honor')
             ->withTimestamps();
     }
+
+    // Alias historis; sama dengan users()
     public function anggota()
     {
-        return $this->belongsToMany(\App\Models\User::class, 'tim_user');
+        return $this->users();
     }
 
     public function creator()

--- a/app/Services/HonorService.php
+++ b/app/Services/HonorService.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+/**
+ * Sumber kebenaran TUNGGAL untuk logika honor.
+ *
+ * Aturan bisnis (dikonfirmasi klien):
+ *  - Honor berbentuk rupiah, PER ORANG PER TIM (disimpan di pivot tim_user.nominal_honor).
+ *  - Tiap ASN punya kuota `maks_honor` (dari eselon jabatannya) = jumlah maksimal
+ *    tim yang DIBAYAR dalam satu tahun anggaran.
+ *  - Kuota RESET per tahun anggaran (tims.tahun).
+ *  - ASN boleh ikut tim melebihi kuota, tapi tim ke-(maks+1) dst TIDAK dibayar.
+ *  - Urutan penentu "siapa yang dibayar": waktu bergabung (tim_user.created_at)
+ *    dari tim yang sudah APPROVED. Tim PENDING hanya prediksi.
+ */
+class HonorService
+{
+    public const DIBAYAR                = 'dibayar';
+    public const TIDAK_DIBAYAR          = 'tidak_dibayar';
+    public const PREDIKSI_DIBAYAR       = 'prediksi_dibayar';
+    public const PREDIKSI_TIDAK_DIBAYAR = 'prediksi_tidak_dibayar';
+
+    public function tahunBerjalan(): int
+    {
+        return (int) now()->year;
+    }
+
+    public function maksHonor(User $asn): int
+    {
+        return (int) ($asn->jabatan?->eselon?->maks_honor ?? 0);
+    }
+
+    /**
+     * Status honor tiap keanggotaan tim milik ASN pada satu tahun anggaran.
+     *
+     * @return Collection<int, array{tim: \App\Models\Tim, nominal: int, status: string, dibayar: bool, urutan: int}>
+     *         di-key berdasarkan tim_id.
+     */
+    public function statusPerTim(User $asn, ?int $tahun = null): Collection
+    {
+        $tahun = $tahun ?? $this->tahunBerjalan();
+        $maks  = $this->maksHonor($asn);
+
+        $tims = $asn->tims()
+            ->where('tims.tahun', $tahun)
+            ->whereIn('tims.status', ['approved', 'pending'])
+            ->orderBy('tim_user.created_at', 'asc') // urutan bergabung (stabil, tak berubah saat edit)
+            ->orderBy('tim_user.id', 'asc')
+            ->get();
+
+        $approved = $tims->where('status', 'approved')->values();
+        $pending  = $tims->where('status', 'pending')->values();
+
+        $hasil = collect();
+
+        foreach ($approved as $i => $tim) {
+            $dibayar = $i < $maks;
+            $hasil->put($tim->id, [
+                'tim'     => $tim,
+                'nominal' => (int) $tim->pivot->nominal_honor,
+                'status'  => $dibayar ? self::DIBAYAR : self::TIDAK_DIBAYAR,
+                'dibayar' => $dibayar,
+                'urutan'  => $i + 1,
+            ]);
+        }
+
+        $approvedCount = $approved->count();
+        foreach ($pending as $j => $tim) {
+            $posisi  = $approvedCount + $j; // posisi (0-based) bila tim ini kelak disetujui
+            $dibayar = $posisi < $maks;
+            $hasil->put($tim->id, [
+                'tim'     => $tim,
+                'nominal' => (int) $tim->pivot->nominal_honor,
+                'status'  => $dibayar ? self::PREDIKSI_DIBAYAR : self::PREDIKSI_TIDAK_DIBAYAR,
+                'dibayar' => false, // prediksi belum benar-benar dibayar
+                'urutan'  => $posisi + 1,
+            ]);
+        }
+
+        return $hasil;
+    }
+
+    /**
+     * Status honor satu ASN untuk SATU tim tertentu (dipakai saat approval / daftar anggota).
+     */
+    public function statusUntukTim(User $asn, int $timId, ?int $tahun = null): ?array
+    {
+        return $this->statusPerTim($asn, $tahun)->get($timId);
+    }
+
+    /**
+     * Ringkasan honor ASN pada satu tahun anggaran.
+     *
+     * @return array{tahun:int, maks_honor:int, jumlah_tim_approved:int, jumlah_dibayar:int,
+     *               jumlah_tidak_dibayar:int, sisa_slot:int, total_honor:int, is_over_limit:bool}
+     */
+    public function ringkasan(User $asn, ?int $tahun = null): array
+    {
+        $tahun  = $tahun ?? $this->tahunBerjalan();
+        $status = $this->statusPerTim($asn, $tahun);
+
+        $approved = $status->whereIn('status', [self::DIBAYAR, self::TIDAK_DIBAYAR]);
+        $dibayar  = $approved->where('dibayar', true);
+        $maks     = $this->maksHonor($asn);
+
+        return [
+            'tahun'                => $tahun,
+            'maks_honor'           => $maks,
+            'jumlah_tim_approved'  => $approved->count(),
+            'jumlah_dibayar'       => $dibayar->count(),
+            'jumlah_tidak_dibayar' => $approved->count() - $dibayar->count(),
+            'sisa_slot'            => max(0, $maks - $dibayar->count()),
+            'total_honor'          => (int) $dibayar->sum('nominal'),
+            'is_over_limit'        => $approved->count() > $maks,
+        ];
+    }
+}

--- a/config/database.php
+++ b/config/database.php
@@ -58,7 +58,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -78,7 +78,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/database/factories/TimFactory.php
+++ b/database/factories/TimFactory.php
@@ -21,6 +21,7 @@ class TimFactory extends Factory
             'nama_tim' => 'Tim ' . $this->faker->word(),
             'keterangan' => $this->faker->sentence(),
             'sk_file' => 'sk/' . $this->faker->uuid() . '.pdf',
+            'tahun' => (int) date('Y'),
             'created_by' => User::inRandomOrder()->first()?->id ?? User::factory(),
             'status' => $this->faker->randomElement(['pending', 'approved', 'rejected']),
         ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -5,7 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
-use app\Models\Jabatan;
+use App\Models\Jabatan;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
@@ -25,13 +25,12 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'nip' => $this->faker->numerify('##########'),
+            'nip' => $this->faker->unique()->numerify('##########'),
             'name' => $this->faker->name(),
-            'email' => $this->faker->safeEmail(),
+            'email' => $this->faker->unique()->safeEmail(),
             'jabatan_id' => Jabatan::inRandomOrder()->first()?->id ?? Jabatan::factory(),
-            'role' => $this->faker->randomElement(['staff', 'admin']),
-            'status_akun' => $this->faker->randomElement(['draft', 'aktif']),
-            'batch' => 1,
+            'role' => 'staff',
+            'status_akun' => 'aktif',
             'email_verified_at' => now(),
             'password' => Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,13 +13,12 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('nip'); //kda pakai unique karena pakai batch. logic login kena di handle controller
+            $table->string('nip')->unique();   // NIP = identitas tetap ASN (1 baris per ASN)
             $table->string('name');
-            $table->string('email'); //kda pakai unique karena pakai batch
-            $table->foreignId('jabatan_id')->constrained('jabatans')->onDelete('cascade');
+            $table->string('email')->unique();
+            $table->foreignId('jabatan_id')->constrained('jabatans')->onDelete('cascade'); // jabatan SAAT INI
             $table->enum('role', ['staff', 'admin'])->default('staff');
-            $table->string('status_akun', 20)->default('draft');
-            $table->unsignedInteger('batch')->default(1); //gasan menyimpan batch update data /3 bulan jr ibu smlm
+            $table->string('status_akun', 20)->default('aktif');
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();

--- a/database/migrations/2025_08_23_075647_create_tims_table.php
+++ b/database/migrations/2025_08_23_075647_create_tims_table.php
@@ -17,19 +17,25 @@ return new class extends Migration
             $table->string('nama_tim');
             $table->text('keterangan');
             $table->string('sk_file');
+            $table->year('tahun');                          // tahun anggaran -> kuota honor reset per tahun
             $table->foreignId('created_by')->constrained('users'); // siapa yg buat
-            $table->enum('status', ['pending', 'approved', 'rejected'])->default('pending'); // ✅ admin approve/reject
+            $table->enum('status', ['pending', 'approved', 'rejected'])->default('pending'); // admin approve/reject
             $table->timestamps();
+
+            $table->index(['tahun', 'status']);
         });
 
 
-        // tabel pivot tim_user
+        // tabel pivot tim_user (keanggotaan ASN dalam tim)
         Schema::create('tim_user', function (Blueprint $table) {
             $table->id();
             $table->foreignId('tim_id')->constrained('tims')->onDelete('cascade');
             $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
-            $table->string('jabatan')->nullable(); // jabatan dalam tim
+            $table->string('jabatan')->nullable();                     // peran dalam tim
+            $table->unsignedBigInteger('nominal_honor')->default(0);   // honor rupiah PER ORANG di tim ini
             $table->timestamps();
+
+            $table->unique(['tim_id', 'user_id']); // 1 ASN tak bisa dobel di tim yang sama
         });
     }
 
@@ -38,6 +44,7 @@ return new class extends Migration
      */
     public function down(): void
     {
+        Schema::dropIfExists('tim_user');
         Schema::dropIfExists('tims');
     }
 };

--- a/database/migrations/2025_08_24_000000_create_jabatan_histories_table.php
+++ b/database/migrations/2025_08_24_000000_create_jabatan_histories_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Riwayat jabatan ASN. Menjaga jejak mutasi/promosi tanpa memutus
+     * keanggotaan tim (yang tetap menempel ke user_id yang sama).
+     */
+    public function up(): void
+    {
+        Schema::create('jabatan_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('jabatan_id')->constrained('jabatans');
+            $table->date('tanggal_mulai');
+            $table->date('tanggal_selesai')->nullable(); // null = jabatan aktif saat ini
+            $table->timestamps();
+
+            $table->index(['user_id', 'tanggal_mulai']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('jabatan_histories');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Models\Eselon;
 use App\Models\Jabatan;
 use App\Models\Tim;
+use App\Models\JabatanHistory;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
@@ -17,52 +18,60 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // Buat 3 eselon
-        $eselons = Eselon::factory()->count(3)->create();
+        // 3 eselon dengan kuota tim-dibayar per tahun yang berbeda
+        $eselons = collect([
+            Eselon::create(['name' => 'Eselon II', 'maks_honor' => 4]),
+            Eselon::create(['name' => 'Eselon III', 'maks_honor' => 3]),
+            Eselon::create(['name' => 'Eselon IV', 'maks_honor' => 2]),
+        ]);
 
-        // Buat jabatan untuk tiap eselon
+        // Jabatan untuk tiap eselon
         $eselons->each(function ($eselon) {
             Jabatan::factory()->count(5)->create([
                 'eselon_id' => $eselon->id,
             ]);
         });
 
-        // Buat 20 user
+        // 20 ASN (staff)
         $users = User::factory()->count(20)->create();
 
-        // Buat 3 tim
-        $tims = Tim::factory()->count(3)->create();
+        // Catat jabatan saat ini sebagai riwayat awal
+        $users->each(function ($user) {
+            JabatanHistory::create([
+                'user_id' => $user->id,
+                'jabatan_id' => $user->jabatan_id,
+                'tanggal_mulai' => now()->startOfYear(),
+            ]);
+        });
 
-        // Assign user ke tim via pivot
+        // 6 tim tahun berjalan
+        $tims = Tim::factory()->count(6)->create();
+
+        // Assign ASN ke tim + nominal honor per orang
         $tims->each(function ($tim) use ($users) {
             $randomUsers = $users->random(rand(3, 7)); // 3-7 anggota
             foreach ($randomUsers as $user) {
                 $tim->users()->attach($user->id, [
-                    'jabatan' => fake()->randomElement(['Ketua', 'Wakil', 'Anggota']),
+                    'jabatan'       => fake()->randomElement(['Ketua', 'Wakil', 'Anggota']),
+                    'nominal_honor' => fake()->randomElement([500000, 750000, 1000000, 1500000]),
                 ]);
             }
         });
 
-        // Tambahkan 1 akun admin default
-        User::factory()->create([
-            'nip' => '0987654321',
-            'name' => 'Super Admin',
-            'email' => 'admin@admin.com',
-            'role' => 'admin',
-            'status_akun' => 'aktif',
-            'password' => Hash::make('password'),
-        ]);
+        // Akun demo
+        $jabatanStaff = Jabatan::inRandomOrder()->first();
 
-        User::factory()->create([
+        User::create([
             'nip' => '1234567890',
-            'name' => 'Staff',
+            'name' => 'Staff Demo',
             'email' => 'staff@staff.com',
+            'jabatan_id' => $jabatanStaff->id,
             'role' => 'staff',
             'status_akun' => 'aktif',
             'password' => Hash::make('password'),
         ]);
 
-        // Call AdminSeeder to seed admin users
+        // Admin default
         $this->call(AdminSeeder::class);
     }
 }

--- a/resources/views/admin/eselons/create.blade.php
+++ b/resources/views/admin/eselons/create.blade.php
@@ -1,0 +1,29 @@
+<x-admin-layout>
+    <div class="container my-4">
+        <div class="card shadow-sm">
+            <div class="card-header bg-white py-3"><h5 class="mb-0">Tambah Eselon</h5></div>
+            <div class="card-body">
+                <form action="{{ route('admin.eselons.store') }}" method="POST">
+                    @csrf
+                    <div class="mb-3">
+                        <label class="form-label">Nama Eselon <span class="text-danger">*</span></label>
+                        <input type="text" name="name" class="form-control @error('name') is-invalid @enderror"
+                            value="{{ old('name') }}" required>
+                        @error('name') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Maks Honor per Tahun (jumlah tim yang dibayar) <span class="text-danger">*</span></label>
+                        <input type="number" name="maks_honor" min="0" max="255"
+                            class="form-control @error('maks_honor') is-invalid @enderror"
+                            value="{{ old('maks_honor') }}" required>
+                        @error('maks_honor') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+                    <div class="d-flex justify-content-end gap-2">
+                        <a href="{{ route('admin.eselons.index') }}" class="btn btn-secondary">Batal</a>
+                        <button class="btn btn-primary">Simpan</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/eselons/edit.blade.php
+++ b/resources/views/admin/eselons/edit.blade.php
@@ -1,0 +1,29 @@
+<x-admin-layout>
+    <div class="container my-4">
+        <div class="card shadow-sm">
+            <div class="card-header bg-white py-3"><h5 class="mb-0">Edit Eselon</h5></div>
+            <div class="card-body">
+                <form action="{{ route('admin.eselons.update', $eselon) }}" method="POST">
+                    @csrf @method('PUT')
+                    <div class="mb-3">
+                        <label class="form-label">Nama Eselon <span class="text-danger">*</span></label>
+                        <input type="text" name="name" class="form-control @error('name') is-invalid @enderror"
+                            value="{{ old('name', $eselon->name) }}" required>
+                        @error('name') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Maks Honor per Tahun (jumlah tim yang dibayar) <span class="text-danger">*</span></label>
+                        <input type="number" name="maks_honor" min="0" max="255"
+                            class="form-control @error('maks_honor') is-invalid @enderror"
+                            value="{{ old('maks_honor', $eselon->maks_honor) }}" required>
+                        @error('maks_honor') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+                    <div class="d-flex justify-content-end gap-2">
+                        <a href="{{ route('admin.eselons.index') }}" class="btn btn-secondary">Batal</a>
+                        <button class="btn btn-primary">Update</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/eselons/index.blade.php
+++ b/resources/views/admin/eselons/index.blade.php
@@ -1,0 +1,54 @@
+<x-admin-layout>
+    <div class="container my-4">
+        @if (session('success'))
+            <div class="alert alert-success">{{ session('success') }}</div>
+        @endif
+        @if (session('error'))
+            <div class="alert alert-danger">{{ session('error') }}</div>
+        @endif
+
+        <div class="card shadow-sm">
+            <div class="card-header bg-white py-3 d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">Master Eselon</h5>
+                <a href="{{ route('admin.eselons.create') }}" class="btn btn-primary btn-sm">
+                    <i class="bi bi-plus-circle"></i> Tambah Eselon
+                </a>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0 align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Nama Eselon</th>
+                                <th>Maks Honor / Tahun</th>
+                                <th>Jumlah Jabatan</th>
+                                <th class="text-end">Aksi</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($eselons as $eselon)
+                                <tr>
+                                    <td>{{ $eselon->name }}</td>
+                                    <td><span class="badge bg-info">{{ $eselon->maks_honor }} tim</span></td>
+                                    <td>{{ $eselon->jabatans_count }}</td>
+                                    <td class="text-end">
+                                        <a href="{{ route('admin.eselons.edit', $eselon) }}" class="btn btn-sm btn-warning">
+                                            <i class="bi bi-pencil"></i>
+                                        </a>
+                                        <form action="{{ route('admin.eselons.destroy', $eselon) }}" method="POST"
+                                            class="d-inline" onsubmit="return confirm('Hapus eselon ini?')">
+                                            @csrf @method('DELETE')
+                                            <button class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr><td colspan="4" class="text-center text-muted py-4">Belum ada eselon.</td></tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/jabatans/create.blade.php
+++ b/resources/views/admin/jabatans/create.blade.php
@@ -1,0 +1,34 @@
+<x-admin-layout>
+    <div class="container my-4">
+        <div class="card shadow-sm">
+            <div class="card-header bg-white py-3"><h5 class="mb-0">Tambah Jabatan</h5></div>
+            <div class="card-body">
+                <form action="{{ route('admin.jabatans.store') }}" method="POST">
+                    @csrf
+                    <div class="mb-3">
+                        <label class="form-label">Nama Jabatan <span class="text-danger">*</span></label>
+                        <input type="text" name="name" class="form-control @error('name') is-invalid @enderror"
+                            value="{{ old('name') }}" required>
+                        @error('name') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Eselon <span class="text-danger">*</span></label>
+                        <select name="eselon_id" class="form-select @error('eselon_id') is-invalid @enderror" required>
+                            <option value="">-- Pilih Eselon --</option>
+                            @foreach ($eselons as $eselon)
+                                <option value="{{ $eselon->id }}" {{ old('eselon_id') == $eselon->id ? 'selected' : '' }}>
+                                    {{ $eselon->name }} (maks {{ $eselon->maks_honor }} tim)
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('eselon_id') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+                    <div class="d-flex justify-content-end gap-2">
+                        <a href="{{ route('admin.jabatans.index') }}" class="btn btn-secondary">Batal</a>
+                        <button class="btn btn-primary">Simpan</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/jabatans/edit.blade.php
+++ b/resources/views/admin/jabatans/edit.blade.php
@@ -1,0 +1,35 @@
+<x-admin-layout>
+    <div class="container my-4">
+        <div class="card shadow-sm">
+            <div class="card-header bg-white py-3"><h5 class="mb-0">Edit Jabatan</h5></div>
+            <div class="card-body">
+                <form action="{{ route('admin.jabatans.update', $jabatan) }}" method="POST">
+                    @csrf @method('PUT')
+                    <div class="mb-3">
+                        <label class="form-label">Nama Jabatan <span class="text-danger">*</span></label>
+                        <input type="text" name="name" class="form-control @error('name') is-invalid @enderror"
+                            value="{{ old('name', $jabatan->name) }}" required>
+                        @error('name') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Eselon <span class="text-danger">*</span></label>
+                        <select name="eselon_id" class="form-select @error('eselon_id') is-invalid @enderror" required>
+                            <option value="">-- Pilih Eselon --</option>
+                            @foreach ($eselons as $eselon)
+                                <option value="{{ $eselon->id }}"
+                                    {{ old('eselon_id', $jabatan->eselon_id) == $eselon->id ? 'selected' : '' }}>
+                                    {{ $eselon->name }} (maks {{ $eselon->maks_honor }} tim)
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('eselon_id') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                    </div>
+                    <div class="d-flex justify-content-end gap-2">
+                        <a href="{{ route('admin.jabatans.index') }}" class="btn btn-secondary">Batal</a>
+                        <button class="btn btn-primary">Update</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/jabatans/index.blade.php
+++ b/resources/views/admin/jabatans/index.blade.php
@@ -1,0 +1,56 @@
+<x-admin-layout>
+    <div class="container my-4">
+        @if (session('success'))
+            <div class="alert alert-success">{{ session('success') }}</div>
+        @endif
+        @if (session('error'))
+            <div class="alert alert-danger">{{ session('error') }}</div>
+        @endif
+
+        <div class="card shadow-sm">
+            <div class="card-header bg-white py-3 d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">Master Jabatan</h5>
+                <a href="{{ route('admin.jabatans.create') }}" class="btn btn-primary btn-sm">
+                    <i class="bi bi-plus-circle"></i> Tambah Jabatan
+                </a>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0 align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Nama Jabatan</th>
+                                <th>Eselon</th>
+                                <th>Maks Honor</th>
+                                <th>Jumlah ASN</th>
+                                <th class="text-end">Aksi</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($jabatans as $jabatan)
+                                <tr>
+                                    <td>{{ $jabatan->name }}</td>
+                                    <td>{{ $jabatan->eselon->name ?? '-' }}</td>
+                                    <td><span class="badge bg-info">{{ $jabatan->eselon->maks_honor ?? 0 }} tim</span></td>
+                                    <td>{{ $jabatan->users_count }}</td>
+                                    <td class="text-end">
+                                        <a href="{{ route('admin.jabatans.edit', $jabatan) }}" class="btn btn-sm btn-warning">
+                                            <i class="bi bi-pencil"></i>
+                                        </a>
+                                        <form action="{{ route('admin.jabatans.destroy', $jabatan) }}" method="POST"
+                                            class="d-inline" onsubmit="return confirm('Hapus jabatan ini?')">
+                                            @csrf @method('DELETE')
+                                            <button class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr><td colspan="5" class="text-center text-muted py-4">Belum ada jabatan.</td></tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/tims/create.blade.php
+++ b/resources/views/admin/tims/create.blade.php
@@ -28,6 +28,17 @@
                         @enderror
                     </div>
 
+                    <!-- Tahun Anggaran -->
+                    <div class="mb-3">
+                        <label for="tahun" class="form-label">Tahun Anggaran <span class="text-danger">*</span></label>
+                        <input type="number" class="form-control @error('tahun') is-invalid @enderror"
+                            id="tahun" name="tahun" min="2000" max="2100"
+                            value="{{ old('tahun', date('Y')) }}" required>
+                        @error('tahun')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
                     <!-- Upload SK -->
                     <div class="mb-3">
                         <label for="sk_file" class="form-label">Upload SK (PDF) <span class="text-danger">*</span></label>
@@ -74,6 +85,7 @@
                                                 <th>Nama</th>
                                                 <th>NIP</th>
                                                 <th>Jabatan</th>
+                                                <th>Honorarium</th>
                                                 <th>Aksi</th>
                                             </tr>
                                         </thead>
@@ -119,18 +131,32 @@
                     closeOnSelect: false
                 });
 
+                // Simpan nominal per user agar tidak hilang saat tabel dirender ulang
+                const nominalValues = {};
+
                 function renderTable() {
                     let tbody = $('#selectedMembers tbody');
+                    tbody.find('.nominal-input').each(function() {
+                        nominalValues[$(this).data('id')] = $(this).val();
+                    });
                     tbody.empty();
 
                     $('#anggota').find(':selected').each(function() {
                         let option = $(this);
                         let id = option.val();
+                        let nominal = nominalValues[id] ?? 0;
                         tbody.append(`
                             <tr data-id="${id}">
                                 <td>${option.text()}</td>
                                 <td>${option.data('nip') || '-'}</td>
                                 <td>${option.data('jabatan') || '-'}</td>
+                                <td>
+                                    <div class="input-group input-group-sm" style="max-width: 170px;">
+                                        <span class="input-group-text">Rp</span>
+                                        <input type="number" name="nominal[${id}]" class="form-control nominal-input"
+                                            data-id="${id}" min="0" step="1000" value="${nominal}" placeholder="0">
+                                    </div>
+                                </td>
                                 <td>
                                     <button type="button" class="btn btn-sm btn-danger remove-member" data-id="${id}">
                                         <i class="bi bi-x-circle"></i> Hapus
@@ -140,6 +166,11 @@
                         `);
                     });
                 }
+
+                // Simpan nominal saat diketik
+                $(document).on('input', '.nominal-input', function() {
+                    nominalValues[$(this).data('id')] = $(this).val();
+                });
 
                 // Update tabel saat select berubah
                 $('#anggota').on('change', renderTable);

--- a/resources/views/admin/tims/edit.blade.php
+++ b/resources/views/admin/tims/edit.blade.php
@@ -44,6 +44,17 @@
                         @enderror
                     </div>
 
+                    <!-- Tahun Anggaran -->
+                    <div class="mb-3">
+                        <label for="tahun" class="form-label">Tahun Anggaran <span class="text-danger">*</span></label>
+                        <input type="number" class="form-control @error('tahun') is-invalid @enderror"
+                            id="tahun" name="tahun" min="2000" max="2100"
+                            value="{{ old('tahun', $tim->tahun) }}" required>
+                        @error('tahun')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
                     <!-- Upload SK -->
                     <div class="mb-3">
                         <label for="sk_file" class="form-label">Upload SK (PDF) <span
@@ -94,6 +105,8 @@
                                                 <th>Nama</th>
                                                 <th>NIP</th>
                                                 <th>Jabatan</th>
+                                                <th>Honorarium</th>
+                                                <th>Aksi</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -138,18 +151,32 @@
                 closeOnSelect: false
             });
 
+            // Nominal honor per user, diisi awal dari data pivot yang tersimpan
+            const nominalValues = @json($tim->users->mapWithKeys(fn($u) => [$u->id => $u->pivot->nominal_honor]));
+
             function renderTable() {
                 let tbody = $('#selectedMembers tbody');
+                tbody.find('.nominal-input').each(function() {
+                    nominalValues[$(this).data('id')] = $(this).val();
+                });
                 tbody.empty();
 
                 $('#anggota').find(':selected').each(function() {
                     let option = $(this);
                     let id = option.val();
+                    let nominal = nominalValues[id] ?? 0;
                     tbody.append(`
                             <tr data-id="${id}">
                                 <td>${option.text()}</td>
                                 <td>${option.data('nip') || '-'}</td>
                                 <td>${option.data('jabatan') || '-'}</td>
+                                <td>
+                                    <div class="input-group input-group-sm" style="max-width: 170px;">
+                                        <span class="input-group-text">Rp</span>
+                                        <input type="number" name="nominal[${id}]" class="form-control nominal-input"
+                                            data-id="${id}" min="0" step="1000" value="${nominal}" placeholder="0">
+                                    </div>
+                                </td>
                                 <td>
                                     <button type="button" class="btn btn-sm btn-danger remove-member" data-id="${id}">
                                         <i class="bi bi-x-circle"></i> Hapus
@@ -159,6 +186,11 @@
                         `);
                 });
             }
+
+            // Simpan nominal saat diketik
+            $(document).on('input', '.nominal-input', function() {
+                nominalValues[$(this).data('id')] = $(this).val();
+            });
 
             // Update tabel saat select berubah
             $('#anggota').on('change', renderTable);

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -52,8 +52,8 @@
                                 <input type="text" class="form-control" value="{{ $user->status_akun }}" readonly>
                             </div>
                             <div class="col-md-6">
-                                <label class="form-label">Batch</label>
-                                <input type="text" class="form-control" value="{{ $user->batch }}" readonly>
+                                <label class="form-label">Eselon</label>
+                                <input type="text" class="form-control" value="{{ $user->jabatan->eselon->name ?? '-' }}" readonly>
                             </div>
                             <div class="col-md-6">
                                 <label class="form-label">Email Verified At</label>
@@ -71,19 +71,22 @@
     <div class="card shadow-sm border-0">
         <div class="card-body">
             <h6 class="fw-bold mb-3 text-danger">
-                <i class="bi bi-exclamation-triangle"></i> Honorarium Progress
+                <i class="bi bi-exclamation-triangle"></i> Progress Honorarium (Tahun {{ $ringkasan['tahun'] }})
             </h6>
 
             @php
-                $taken = $totalTim;
-                $limit = $maksHonor;
-                $percent = $limit > 0 ? ($taken / $limit) * 100 : 0;
-                $percent = min($percent, 100);
+                $taken = $ringkasan['jumlah_dibayar'];
+                $limit = $ringkasan['maks_honor'];
+                $approved = $ringkasan['jumlah_tim_approved'];
+                $percent = $limit > 0 ? min(($taken / $limit) * 100, 100) : 0;
             @endphp
 
-            <p class="mb-1">Sudah diambil: <strong>{{ $taken }}/{{ $limit }}</strong></p>
+            <p class="mb-1">Tim dibayar: <strong>{{ $taken }}/{{ $limit }}</strong>
+                &middot; Total tim approved: <strong>{{ $approved }}</strong>
+                &middot; Total honor: <strong>Rp {{ number_format($ringkasan['total_honor'], 0, ',', '.') }}</strong>
+            </p>
             <div class="progress" style="height: 20px;">
-                <div class="progress-bar {{ $taken > $limit ? 'bg-danger' : 'bg-success' }}"
+                <div class="progress-bar {{ $ringkasan['is_over_limit'] ? 'bg-danger' : 'bg-success' }}"
                      role="progressbar"
                      style="width: {{ $percent }}%;"
                      aria-valuenow="{{ $percent }}"
@@ -93,11 +96,11 @@
                 </div>
             </div>
 
-            @if ($taken > $limit)
+            @if ($ringkasan['is_over_limit'])
                 <div class="alert alert-warning p-2 mt-2 mb-0">
                     <small>
-                        Anda telah melebihi batas maksimal honorarium ({{ $limit }}).
-                        Honor berikutnya tidak bisa diterima.
+                        ASN ini mengikuti {{ $approved }} tim approved, melebihi kuota {{ $limit }}.
+                        Tim di luar kuota tidak menerima honor.
                     </small>
                 </div>
             @endif

--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -28,6 +28,18 @@
           <i class="bi bi-people-fill text-white me-1"></i>
           <a class="nav-link {{ request()->routeIs('admin.tims.*') ? 'active' : '' }}" href="{{ route('admin.tims.index') }}">Team</a>
         </li>
+
+        <!-- Eselon -->
+        <li class="nav-item d-flex align-items-center me-3">
+          <i class="bi bi-diagram-3 text-white me-1"></i>
+          <a class="nav-link {{ request()->routeIs('admin.eselons.*') ? 'active' : '' }}" href="{{ route('admin.eselons.index') }}">Eselon</a>
+        </li>
+
+        <!-- Jabatan -->
+        <li class="nav-item d-flex align-items-center me-3">
+          <i class="bi bi-briefcase text-white me-1"></i>
+          <a class="nav-link {{ request()->routeIs('admin.jabatans.*') ? 'active' : '' }}" href="{{ route('admin.jabatans.index') }}">Jabatan</a>
+        </li>
       </ul>
 
       <!-- Auth Buttons -->

--- a/resources/views/staff/index.blade.php
+++ b/resources/views/staff/index.blade.php
@@ -65,16 +65,9 @@
                         </h6>
 
                         @php
-                            $timsApprovedUser = $user
-                                ->tims()
-                                ->where('tims.status', 'approved')
-                                ->orderBy('tims.updated_at', 'asc')
-                                ->get();
-
-                            $actualHonorCount = min($timsApprovedUser->count(), $maksHonor);
-                            $totalTimApproved = $timsApprovedUser->count();
-
-                            $progress = $maksHonor > 0 ? ($actualHonorCount / $maksHonor) * 100 : 0;
+                            $actualHonorCount = $ringkasanDiri['jumlah_dibayar'];
+                            $totalTimApproved = $ringkasanDiri['jumlah_tim_approved'];
+                            $progress = $maksHonor > 0 ? min(100, ($actualHonorCount / $maksHonor) * 100) : 0;
                         @endphp
 
                         <div class="progress mb-3" style="height: 25px;">

--- a/resources/views/staff/profile.blade.php
+++ b/resources/views/staff/profile.blade.php
@@ -1,0 +1,73 @@
+<x-staff-layout>
+    <div class="container py-4">
+        <h2 class="mb-4 fw-bold text-primary">Profil Saya</h2>
+
+        <div class="row g-4">
+            <div class="col-lg-5">
+                <div class="card shadow-sm border-0 rounded-3 h-100">
+                    <div class="card-body p-4">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="rounded-circle bg-primary text-white d-flex align-items-center justify-content-center fs-4 fw-bold me-3"
+                                style="width:60px;height:60px;">
+                                {{ strtoupper(substr($user->name, 0, 1)) }}
+                            </div>
+                            <div>
+                                <h5 class="mb-0 fw-bold">{{ $user->name }}</h5>
+                                <small class="text-muted">NIP. {{ $user->nip }}</small>
+                            </div>
+                        </div>
+                        <hr>
+                        <p class="mb-2"><strong>Email:</strong> {{ $user->email }}</p>
+                        <p class="mb-2"><strong>Jabatan:</strong> {{ $user->jabatan->name }}</p>
+                        <p class="mb-0"><strong>Eselon:</strong> {{ $user->jabatan->eselon->name ?? '-' }}</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-lg-7">
+                <div class="card shadow-sm border-0 rounded-3 h-100">
+                    <div class="card-body p-4">
+                        <h5 class="fw-bold text-primary mb-3">
+                            <i class="bi bi-cash-coin me-2"></i>Honor Tahun {{ $ringkasan['tahun'] }}
+                        </h5>
+
+                        <div class="row text-center g-3">
+                            <div class="col-6 col-md-3">
+                                <div class="p-3 bg-light rounded-3">
+                                    <div class="fs-4 fw-bold text-dark">{{ $ringkasan['jumlah_dibayar'] }}/{{ $ringkasan['maks_honor'] }}</div>
+                                    <small class="text-muted">Tim Dibayar</small>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="p-3 bg-light rounded-3">
+                                    <div class="fs-4 fw-bold text-dark">{{ $ringkasan['jumlah_tim_approved'] }}</div>
+                                    <small class="text-muted">Total Tim Approved</small>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="p-3 bg-light rounded-3">
+                                    <div class="fs-4 fw-bold text-dark">{{ $ringkasan['sisa_slot'] }}</div>
+                                    <small class="text-muted">Sisa Slot</small>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="p-3 bg-light rounded-3">
+                                    <div class="fs-6 fw-bold text-success">Rp {{ number_format($ringkasan['total_honor'], 0, ',', '.') }}</div>
+                                    <small class="text-muted">Total Honor</small>
+                                </div>
+                            </div>
+                        </div>
+
+                        @if ($ringkasan['is_over_limit'])
+                            <div class="alert alert-warning mt-4 mb-0 rounded-3">
+                                <i class="bi bi-exclamation-triangle-fill me-2"></i>
+                                Anda mengikuti {{ $ringkasan['jumlah_tim_approved'] }} tim approved, melebihi kuota
+                                {{ $ringkasan['maks_honor'] }}. Tim di luar kuota tidak menerima honor.
+                            </div>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-staff-layout>

--- a/resources/views/staff/tim/create.blade.php
+++ b/resources/views/staff/tim/create.blade.php
@@ -201,6 +201,9 @@
     @push('scripts')
         <script>
             $(document).ready(function() {
+                // Simpan nominal honor per user agar tidak hilang saat tabel dirender ulang
+                const nominalValues = {};
+
                 // Inisialisasi Select2
                 $('.select2-multiple').select2({
                     theme: 'bootstrap-5',
@@ -219,6 +222,10 @@
                 // Fungsi untuk memperbarui tabel preview
                 function updateSelectedMembersTable() {
                     let tbody = $('#selectedMembers tbody');
+                    // Simpan dulu nilai nominal yang sedang diketik sebelum tabel dikosongkan
+                    tbody.find('.nominal-input').each(function() {
+                        nominalValues[$(this).data('id')] = $(this).val();
+                    });
                     tbody.empty();
 
                     // Dapatkan ID user yang sedang login
@@ -280,21 +287,30 @@
                             actionButton = `<button type="button" class="btn btn-sm btn-danger remove-member" data-id="${userId}"><i class="bi bi-trash"></i></button>`;
                         }
 
+                        let nominal = nominalValues[userId] ?? 0;
                         tbody.append(`
                             <tr class="${rowClass}">
                                 <td>${option.text()}</td>
                                 <td>${option.data('nip')}</td>
                                 <td>${option.data('jabatan')}</td>
                                 <td>
-                                    <span class="badge ${badgeClass}">
-                                        ${honorStatusText}
-                                    </span>
+                                    <div class="input-group input-group-sm" style="max-width: 170px;">
+                                        <span class="input-group-text">Rp</span>
+                                        <input type="number" name="nominal[${userId}]" class="form-control nominal-input"
+                                            data-id="${userId}" min="0" step="1000" value="${nominal}" placeholder="0">
+                                    </div>
+                                    <span class="badge ${badgeClass} mt-1">${honorStatusText}</span>
                                 </td>
                                 <td>${actionButton}</td>
                             </tr>
                         `);
                     });
                 }
+
+                // Simpan nominal saat diketik (event delegation karena baris dibuat dinamis)
+                $(document).on('input', '.nominal-input', function() {
+                    nominalValues[$(this).data('id')] = $(this).val();
+                });
 
                 // Panggil fungsi update saat Select2 berubah
                 $('#anggota').on('change', function() {

--- a/resources/views/staff/tim/index.blade.php
+++ b/resources/views/staff/tim/index.blade.php
@@ -26,18 +26,18 @@
             </div>
         </div>
 
-        <!-- Filter Batch Card -->
+        <!-- Filter Tahun Anggaran Card -->
         <div class="card shadow-sm border-0 mb-4">
             <div class="card-body py-3">
                 <div class="row g-2 align-items-center">
                     <div class="col-auto">
-                        <label for="batchFilter" class="col-form-label text-muted">Filter Berdasarkan Batch:</label>
+                        <label for="tahunFilter" class="col-form-label text-muted">Filter Tahun Anggaran:</label>
                     </div>
                     <div class="col-auto">
-                        <select class="form-select form-select-sm" id="batchFilter">
-                            @foreach ($batches as $batch)
-                                <option value="{{ $batch }}" {{ $selectedBatch == $batch ? 'selected' : '' }}>
-                                    Batch {{ $batch }}
+                        <select class="form-select form-select-sm" id="tahunFilter">
+                            @foreach ($tahunList as $th)
+                                <option value="{{ $th }}" {{ $tahun == $th ? 'selected' : '' }}>
+                                    Tahun {{ $th }}
                                 </option>
                             @endforeach
                         </select>
@@ -245,8 +245,8 @@
 
     @push('scripts')
         <script>
-            document.getElementById('batchFilter').addEventListener('change', function() {
-                window.location.href = '{{ route('staff.tim.index') }}?batch=' + this.value;
+            document.getElementById('tahunFilter').addEventListener('change', function() {
+                window.location.href = '{{ route('staff.tim.index') }}?tahun=' + this.value;
             });
 
             // Initialize tooltips

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\StaffController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Admin\TimController as AdminTimController;
+use App\Http\Controllers\EselonController;
+use App\Http\Controllers\JabatanController;
 use Illuminate\Support\Facades\Auth;
 
 Route::redirect('/', '/login');
@@ -45,6 +47,10 @@ Route::middleware(['auth'])->group(function () {
 
         // CRUD Users
         Route::resource('users', UserController::class);
+
+        // Master data: Eselon & Jabatan (konfigurasi kuota honor)
+        Route::resource('eselons', EselonController::class)->except(['show']);
+        Route::resource('jabatans', JabatanController::class)->except(['show']);
 
         // CRUD Tims
         Route::resource('tims', AdminTimController::class);

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -10,10 +10,10 @@ class ExampleTest extends TestCase
     /**
      * A basic test example.
      */
-    public function test_the_application_returns_a_successful_response(): void
+    public function test_the_application_redirects_guests_to_login(): void
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/login');
     }
 }

--- a/tests/Feature/HonorFlowTest.php
+++ b/tests/Feature/HonorFlowTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Models\Tim;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(\Database\Seeders\DatabaseSeeder::class);
+    $this->staff = User::where('role', 'staff')->first();
+    $this->admin = User::where('role', 'admin')->first();
+});
+
+it('renders semua halaman staff tanpa error', function () {
+    $this->actingAs($this->staff);
+
+    $this->get('/staff/dashboard')->assertOk();
+    $this->get('/staff/tim')->assertOk();
+    $this->get('/staff/tim/create')->assertOk();
+    $this->get('/staff/profile')->assertOk();
+});
+
+it('renders halaman admin tanpa error', function () {
+    $this->actingAs($this->admin);
+
+    $this->get('/admin/dashboard')->assertOk();
+    $this->get('/admin/tims/create')->assertOk();
+
+    $tim = Tim::first();
+    $this->get("/admin/tims/{$tim->id}")->assertOk();          // show
+    $this->get("/admin/tims/{$tim->id}/edit")->assertOk();     // edit
+
+    $staff = User::where('role', 'staff')->first();
+    $this->get("/admin/users/{$staff->id}")->assertOk();       // show
+
+    $this->getJson("/admin/tims/{$tim->id}/check-members")
+        ->assertOk()
+        ->assertJsonStructure(['members', 'has_over_limit', 'has_warning']);
+});
+
+it('admin bisa mengelola master eselon & jabatan', function () {
+    $this->actingAs($this->admin);
+
+    $this->get('/admin/eselons')->assertOk();
+    $this->get('/admin/eselons/create')->assertOk();
+    $this->get('/admin/jabatans')->assertOk();
+    $this->get('/admin/jabatans/create')->assertOk();
+
+    $this->post('/admin/eselons', ['name' => 'Eselon Baru', 'maks_honor' => 5])
+        ->assertRedirect(route('admin.eselons.index'));
+    $eselon = \App\Models\Eselon::where('name', 'Eselon Baru')->first();
+    expect($eselon->maks_honor)->toBe(5);
+
+    $this->post('/admin/jabatans', ['name' => 'Kepala Baru', 'eselon_id' => $eselon->id])
+        ->assertRedirect(route('admin.jabatans.index'));
+    expect(\App\Models\Jabatan::where('name', 'Kepala Baru')->exists())->toBeTrue();
+});
+
+it('mencatat riwayat jabatan saat jabatan ASN berubah', function () {
+    $this->actingAs($this->admin);
+
+    $target = User::where('role', 'staff')->first();
+    $jabatanBaru = \App\Models\Jabatan::where('id', '!=', $target->jabatan_id)->first();
+
+    $this->put("/admin/users/{$target->id}", [
+        'nip'        => $target->nip,
+        'name'       => $target->name,
+        'email'      => $target->email,
+        'jabatan_id' => $jabatanBaru->id,
+        'role'       => $target->role,
+    ])->assertRedirect(route('admin.users.index'));
+
+    // Ada riwayat lama yang ditutup + riwayat baru yang terbuka
+    expect($target->jabatanHistories()->whereNotNull('tanggal_selesai')->count())->toBeGreaterThanOrEqual(1);
+    expect($target->jabatanHistories()->where('jabatan_id', $jabatanBaru->id)->whereNull('tanggal_selesai')->exists())->toBeTrue();
+});
+
+it('staff bisa membuat tim dengan nominal honor per anggota', function () {
+    Storage::fake('public');
+    $this->actingAs($this->staff);
+
+    $response = $this->post('/staff/tim', [
+        'nama_tim'   => 'Tim Uji Otomatis',
+        'keterangan' => 'keterangan uji',
+        'sk_file'    => UploadedFile::fake()->create('sk.pdf', 50, 'application/pdf'),
+        'anggota'    => [$this->staff->id],
+        'nominal'    => [$this->staff->id => 1250000],
+    ]);
+
+    $response->assertRedirect(route('staff.tim.index'));
+
+    $tim = Tim::where('nama_tim', 'Tim Uji Otomatis')->first();
+    expect($tim)->not->toBeNull();
+    expect((int) $tim->tahun)->toBe((int) date('Y'));
+    expect((int) $tim->users()->where('user_id', $this->staff->id)->first()->pivot->nominal_honor)->toBe(1250000);
+});


### PR DESCRIPTION
… keanggotaan

Audit menyeluruh menemukan 3 versi logika "tim mana yang dapat honor" saling bertentangan antara staff/admin/approval (beda hasil angka), tidak ada scoping tahun anggaran, dan honor dihitung sebagai jumlah tim (bukan rupiah) sehingga tak bisa dipakai untuk audit kekurangan bayar akhir tahun. Model NIP/batch lama juga memutus riwayat honor tiap ASN pindah eselon/jabatan.

- Tambah app/Services/HonorService.php sebagai single source of truth untuk status honor per ASN per tahun (dipakai staff, admin, approval)
- Tambah kolom tims.tahun (tahun anggaran) + tim_user.nominal_honor (nominal rupiah per keanggotaan, unique per tim+user)
- users.nip jadi unik, hapus kolom batch; riwayat jabatan dipindah ke tabel jabatan_histories (JabatanHistory) agar identitas ASN stabil lintas mutasi/promosi
- CRUD penuh untuk Eselon & Jabatan (sebelumnya tanpa route/view)
- Fix bug: route staff.profile.index 500, sync() pivot jabatan ke-reset saat edit tim, SK file disimpan ke disk berbeda antara create & edit, cookie remember_web manual yang redundan
- Tambah tests/Feature/HonorFlowTest.php

Data lama tidak kompatibel dengan skema baru — perlu `php artisan migrate:fresh --seed`.