### PR TITLE
Refactor staff UI/UX per design mockup — custom CSS, mobile bottom na…

### DIFF
--- a/app/Http/Controllers/StaffController.php
+++ b/app/Http/Controllers/StaffController.php
@@ -27,7 +27,8 @@ class StaffController extends Controller
      * Bangun peta status honor per (anggota, tim) untuk sekumpulan tim.
      * Menghitung per tahun anggaran masing-masing tim, dengan cache per (anggota, tahun).
      *
-     * @return array{0: array<int,array<int,string>>, 1: array<int,int>}  [statusHonorPerTim, timCountPerUser(tahun berjalan)]
+     * @return array{0: array<int,array<int,array{status:string,label:string}>>, 1: array<int,int>}
+     *         [statusHonorPerTim, timCountPerUser(tahun berjalan)]
      */
     private function buildStatusMap($tims, HonorService $honor): array
     {
@@ -41,7 +42,10 @@ class StaffController extends Controller
             foreach ($tim->users as $anggota) {
                 $s = $resolve($anggota, (int) $tim->tahun)->get($tim->id);
                 if ($s) {
-                    $statusHonorPerTim[$anggota->id][$tim->id] = $this->legacyLabel[$s['status']] ?? $s['status'];
+                    $statusHonorPerTim[$anggota->id][$tim->id] = [
+                        'status' => $s['status'],
+                        'label'  => $this->legacyLabel[$s['status']] ?? $s['status'],
+                    ];
                 }
             }
         }
@@ -60,15 +64,17 @@ class StaffController extends Controller
     public function indexDashboard(HonorService $honor)
     {
         $user = Auth::user()->load('jabatan.eselon');
+        $tahunBerjalan = $honor->tahunBerjalan();
 
         $tims = $user->tims()
+            ->where('tims.tahun', $tahunBerjalan)
             ->with(['users.jabatan.eselon'])
             ->latest()
             ->get();
 
         [$statusHonorPerTim, $timCountPerUser] = $this->buildStatusMap($tims, $honor);
 
-        $ringkasanDiri = $honor->ringkasan($user);
+        $ringkasanDiri = $honor->ringkasan($user, $tahunBerjalan);
         $maksHonor = $ringkasanDiri['maks_honor'];
         $totalTim  = $ringkasanDiri['jumlah_dibayar']; // honor diterima tahun berjalan
 
@@ -79,7 +85,8 @@ class StaffController extends Controller
             'maksHonor',
             'ringkasanDiri',
             'timCountPerUser',
-            'statusHonorPerTim'
+            'statusHonorPerTim',
+            'tahunBerjalan'
         ));
     }
 
@@ -127,7 +134,8 @@ class StaffController extends Controller
             'approvedTimCount',
             'maksHonor',
             'progress',
-            'statusHonorPerTim'
+            'statusHonorPerTim',
+            'ringkasan'
         ));
     }
 
@@ -201,7 +209,8 @@ class StaffController extends Controller
 
             return redirect()
                 ->route('staff.tim.index')
-                ->with('success', 'Tim berhasil dibuat dan menunggu persetujuan admin.');
+                ->with('success', 'Tim berhasil dibuat dan menunggu persetujuan admin.')
+                ->with('teamName', $tim->nama_tim);
         } catch (\Throwable $e) {
             DB::rollBack();
             if (isset($skPath)) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,6 +35,18 @@ class User extends Authenticatable
         return $this->hasMany(Tim::class, 'created_by');
     }
 
+    /**
+     * Inisial nama untuk avatar bubble, mis. "Budi Santoso" -> "BS".
+     */
+    public function getInitialsAttribute(): string
+    {
+        $parts = preg_split('/\s+/', trim($this->name ?? ''));
+        $first = $parts[0][0] ?? '';
+        $second = $parts[1][0] ?? '';
+
+        return mb_strtoupper($first . $second);
+    }
+
     public function tims()
     {
         return $this->belongsToMany(Tim::class, 'tim_user')

--- a/public/css/staff-app.css
+++ b/public/css/staff-app.css
@@ -1,0 +1,346 @@
+/* ===== Anugerah ASN — Staff design system ===== */
+
+:root {
+  --aksen: #3562E3;
+  --aksen-tint: #3562E314;
+  --aksen-line: #3562E34D;
+  --aksen-dark: #2A50C4;
+
+  --ink: #17233B;
+  --muted: #5C6B85;
+  --muted2: #8B99B3;
+  --muted3: #9AA7BD;
+
+  --border: #E2E7F0;
+  --border2: #E6EAF3;
+  --border3: #EDF0F7;
+  --border4: #F2F4FA;
+
+  --bg: #F2F5FB;
+
+  --success: #17915F;
+  --success-bg: #E4F5EE;
+  --warning: #B96E00;
+  --warning-bg: #FBF0DC;
+  --warning-ink: #7A5A15;
+  --danger: #D14343;
+  --danger-bg: #FBEAEA;
+
+  --shadow-card: 0 1px 2px rgba(23,35,59,.05), 0 16px 40px -24px rgba(23,35,59,.18);
+  --shadow-card-sm: 0 1px 2px rgba(23,35,59,.05), 0 12px 28px -20px rgba(23,35,59,.16);
+  --shadow-btn: 0 10px 24px -10px var(--aksen-line);
+}
+
+* { box-sizing: border-box; }
+
+/* Elements toggled via the `hidden` attribute also carry display-setting classes
+   (.flex, .flex-col, .file-card, .dropzone, .err-box, ...). Author rules always
+   beat the UA stylesheet's `[hidden]{display:none}`, so without this override
+   those classes would silently defeat `hidden`. */
+[hidden] { display: none !important; }
+
+body.staff-app {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+}
+
+.staff-app input::placeholder,
+.staff-app textarea::placeholder { color: var(--muted3); }
+.staff-app input, .staff-app textarea, .staff-app button, .staff-app select {
+  font-family: inherit;
+}
+
+a { text-decoration: none; color: inherit; }
+
+/* ---------- layout shell ---------- */
+.staff-topbar {
+  position: sticky; top: 0; z-index: 50;
+  background: rgba(255,255,255,.92);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border2);
+}
+.staff-topbar-inner {
+  max-width: 1120px; margin: 0 auto; padding: 0 20px;
+  height: 62px; display: flex; align-items: center; gap: 20px;
+}
+.staff-logo { display: flex; align-items: center; gap: 10px; cursor: pointer; }
+.staff-logo-mark {
+  width: 34px; height: 34px; border-radius: 10px; background: var(--aksen); color: #fff;
+  display: flex; align-items: center; justify-content: center; font-size: 17px; font-weight: 800; flex-shrink: 0;
+}
+.staff-logo-text { font-size: 16.5px; font-weight: 800; letter-spacing: -0.2px; white-space: nowrap; }
+
+.staff-nav { display: flex; align-items: center; gap: 4px; margin-left: 12px; }
+.staff-nav-item {
+  height: 38px; padding: 0 16px; border: none; border-radius: 999px; font-size: 14px; font-weight: 600;
+  color: var(--muted); background: transparent; cursor: pointer; transition: background .15s ease; display: inline-flex; align-items: center;
+}
+.staff-nav-item:hover { background: #F0F3F9; }
+.staff-nav-item.active { font-weight: 700; color: var(--aksen); background: var(--aksen-tint); }
+.staff-nav-item.active:hover { background: var(--aksen-tint); }
+
+.staff-spacer { flex: 1; }
+
+.btn {
+  height: 40px; padding: 0 18px; border: none; border-radius: 12px; font-size: 14px; font-weight: 700;
+  cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  transition: background .15s ease, border-color .15s ease, color .15s ease;
+}
+.btn-primary { background: var(--aksen); color: #fff; box-shadow: var(--shadow-btn); }
+.btn-primary:hover { background: var(--aksen-dark); }
+.btn-primary:disabled { background: var(--border); color: var(--muted3); cursor: not-allowed; box-shadow: none; }
+.btn-secondary { background: #fff; color: var(--ink); border: 1.5px solid var(--border); }
+.btn-secondary:hover { border-color: #C6CFDF; }
+.btn-ghost { background: transparent; color: var(--muted); border: 1px solid var(--border2); }
+.btn-ghost:hover { color: var(--danger); border-color: #F3C6C6; background: #FDF6F6; }
+.btn-link { background: transparent; border: none; color: var(--aksen); font-size: 13px; font-weight: 700; cursor: pointer; padding: 0; }
+.btn-link:hover { text-decoration: underline; }
+.btn-icon {
+  width: 38px; height: 38px; border: 1px solid var(--border2); background: #fff; border-radius: 12px;
+  cursor: pointer; color: var(--muted2); display: flex; align-items: center; justify-content: center;
+}
+.btn-icon:hover { color: var(--danger); border-color: #F3C6C6; background: #FDF6F6; }
+
+.staff-profile-btn {
+  display: flex; align-items: center; gap: 10px; border: none; background: transparent; cursor: pointer;
+  padding: 6px 8px; border-radius: 12px; text-align: left;
+}
+.staff-profile-btn:hover { background: #F0F3F9; }
+.staff-profile-name { font-size: 13.5px; font-weight: 700; color: var(--ink); line-height: 1.2; }
+.staff-profile-role { font-size: 11.5px; color: var(--muted2); line-height: 1.2; }
+
+.avatar {
+  border-radius: 999px; background: var(--aksen-tint); color: var(--aksen);
+  display: flex; align-items: center; justify-content: center; font-weight: 800; flex-shrink: 0;
+}
+.avatar-34 { width: 34px; height: 34px; font-size: 13px; }
+.avatar-36 { width: 36px; height: 36px; font-size: 13px; border: 1.5px solid var(--aksen-line); }
+.avatar-42 { width: 42px; height: 42px; font-size: 15px; }
+.avatar-62 { width: 62px; height: 62px; font-size: 21px; background: var(--aksen); color: #fff; }
+.avatar-solid { background: var(--aksen); color: #fff; }
+.avatar-32 { width: 32px; height: 32px; font-size: 11.5px; }
+.avatar-30 { width: 30px; height: 30px; font-size: 11px; }
+
+.staff-divider-v { width: 1px; height: 26px; background: var(--border2); }
+
+.staff-main { max-width: 1120px; margin: 0 auto; padding: 28px 20px 60px; }
+
+.staff-bottomnav {
+  display: none;
+  position: fixed; bottom: 0; left: 0; right: 0; z-index: 60;
+  background: rgba(255,255,255,.96); backdrop-filter: blur(10px);
+  border-top: 1px solid var(--border2); box-shadow: 0 -8px 24px -12px rgba(23,35,59,.15);
+  align-items: stretch; padding-bottom: env(safe-area-inset-bottom);
+}
+.staff-bottomnav-item {
+  flex: 1; min-height: 60px; border: none; background: transparent; cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px;
+  color: var(--muted2); font-family: inherit;
+}
+.staff-bottomnav-item.active { color: var(--aksen); }
+.staff-bottomnav-item svg { width: 21px; height: 21px; }
+.staff-bottomnav-label { font-size: 10.5px; font-weight: 700; }
+.staff-bottomnav-fab-wrap { justify-content: flex-end; padding-bottom: 8px; color: var(--muted); }
+.staff-bottomnav-fab {
+  width: 46px; height: 46px; margin-top: -24px; border-radius: 999px; background: var(--aksen); color: #fff;
+  display: flex; align-items: center; justify-content: center; box-shadow: 0 10px 22px -8px var(--aksen-line);
+  border: 3px solid var(--bg);
+}
+.staff-bottomnav-fab svg { width: 20px; height: 20px; }
+
+.staff-mobile-only { display: none !important; }
+.staff-desktop-only { display: flex !important; }
+
+.profile-grid { display: grid; grid-template-columns: minmax(300px, 380px) 1fr; gap: 16px; align-items: start; }
+
+@media (max-width: 767.98px) {
+  .staff-main { padding: 20px 16px 110px; }
+  .staff-desktop-only { display: none !important; }
+  .staff-mobile-only { display: flex !important; }
+  .staff-bottomnav { display: flex; }
+  .profile-grid { display: none !important; }
+}
+
+/* ---------- generic building blocks ---------- */
+.card {
+  background: #fff; border-radius: 20px; box-shadow: var(--shadow-card);
+}
+.card-sm { border-radius: 16px; box-shadow: var(--shadow-card-sm); }
+
+.h1-page { margin: 0 0 4px; font-size: 24px; font-weight: 800; letter-spacing: -0.3px; }
+.sub-page { font-size: 13.5px; color: var(--muted); }
+
+.field-label { font-size: 13.5px; font-weight: 700; }
+.field-hint { font-size: 12.5px; color: var(--muted2); }
+.field-required { color: var(--danger); }
+
+.input, .textarea {
+  border: 1.5px solid var(--border); border-radius: 12px; padding: 0 14px; font-size: 14.5px;
+  background: #FBFCFE; outline: none; color: var(--ink); width: 100%;
+}
+.input { height: 46px; }
+.textarea { padding: 12px 14px; resize: vertical; line-height: 1.55; }
+.input:focus, .textarea:focus {
+  border-color: var(--aksen); background: #fff; box-shadow: 0 0 0 4px var(--aksen-tint);
+}
+.input-pill { height: 38px; border-radius: 999px; padding: 0 14px 0 36px; font-size: 13.5px; background: #fff; }
+
+.badge-pill {
+  font-size: 12px; font-weight: 700; padding: 6px 12px; border-radius: 999px; display: inline-flex; align-items: center; gap: 4px;
+}
+.badge-success { background: var(--success-bg); color: var(--success); }
+.badge-warning { background: var(--warning-bg); color: var(--warning); }
+.badge-danger { background: var(--danger-bg); color: var(--danger); }
+.badge-neutral { background: var(--border3); color: var(--muted); }
+.badge-accent { background: var(--aksen-tint); color: var(--aksen); }
+
+.chip {
+  height: 32px; padding: 0 14px; border-radius: 999px; font-size: 13px; font-weight: 700; cursor: pointer;
+  border: 1.5px solid var(--border); background: #fff; color: var(--muted); transition: all .15s ease;
+}
+.chip:hover { border-color: var(--aksen); }
+.chip.active { border-color: transparent; background: var(--aksen); color: #fff; }
+
+.slot-bar { flex: 1; height: 14px; border-radius: 7px; background: #fff; border: 2px dashed #D8DFEC; }
+.slot-bar.filled { background: var(--aksen); border: 2px solid transparent; }
+.slot-bar-sm { height: 10px; border-radius: 5px; max-width: 72px; }
+
+.chevron { width: 18px; height: 18px; color: var(--muted2); transition: transform .2s ease; flex-shrink: 0; }
+.chevron.open { transform: rotate(180deg); }
+
+/* ---------- expandable list/table rows ---------- */
+.team-card { overflow: hidden; }
+.team-card-head {
+  display: flex; align-items: center; gap: 14px; padding: 16px 18px; cursor: pointer; flex-wrap: wrap; border: none;
+  background: transparent; width: 100%; text-align: left; font-family: inherit;
+}
+.team-card-head:hover { background: #FAFBFE; }
+.team-card-icon {
+  width: 42px; height: 42px; border-radius: 12px; display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+}
+.team-card-icon svg { width: 20px; height: 20px; }
+.team-card-body { border-top: 1px solid var(--border3); padding: 16px 18px 18px; background: #FBFCFE; }
+
+.member-row { display: flex; align-items: center; gap: 12px; padding: 8px 10px; border-radius: 10px; }
+.member-row:hover { background: #F0F3F9; }
+
+.ptatk-table { width: 100%; border-collapse: collapse; }
+.ptatk-table-head {
+  display: grid; grid-template-columns: 1fr 130px 170px 200px 44px; gap: 12px; padding: 14px 22px;
+  border-bottom: 1px solid var(--border3); font-size: 11.5px; font-weight: 800; letter-spacing: .6px; color: var(--muted2);
+}
+.ptatk-row-head {
+  display: grid; grid-template-columns: 1fr 130px 170px 200px 44px; gap: 12px; padding: 15px 22px; align-items: center;
+  cursor: pointer; border: none; background: transparent; width: 100%; text-align: left; font-family: inherit;
+}
+.ptatk-row-head:hover { background: #FAFBFE; }
+.ptatk-row-wrap { border-bottom: 1px solid var(--border4); }
+.ptatk-row-wrap:last-child { border-bottom: none; }
+.ptatk-row-body { padding: 4px 22px 18px; background: #FBFCFE; }
+
+@media (max-width: 900px) {
+  .ptatk-table-head, .ptatk-row-head { grid-template-columns: 1fr 100px 140px; }
+  .ptatk-table-head > div:nth-child(4), .ptatk-row-head > div:nth-child(4) { display: none; }
+}
+
+/* ---------- year tabs ---------- */
+.year-tabs { display: flex; background: #E9EDF5; border-radius: 12px; padding: 4px; gap: 2px; }
+.year-tab {
+  height: 34px; padding: 0 18px; border: none; border-radius: 9px; font-size: 13.5px; font-weight: 700; cursor: pointer;
+  background: transparent; color: var(--muted2); transition: all .15s ease;
+}
+.year-tab.active { background: #fff; color: var(--ink); box-shadow: 0 2px 8px rgba(23,35,59,.12); }
+
+/* ---------- wizard ---------- */
+.stepper { display: flex; align-items: center; margin-bottom: 20px; }
+.stepper-item { display: flex; align-items: center; }
+.stepper-circle {
+  width: 32px; height: 32px; border-radius: 999px; display: flex; align-items: center; justify-content: center;
+  font-size: 13px; font-weight: 800; background: #fff; color: var(--muted2); border: 2px solid #D8DFEC;
+  box-sizing: border-box; flex-shrink: 0; transition: all .2s ease;
+}
+.stepper-circle svg { width: 15px; height: 15px; }
+.stepper-circle.done, .stepper-circle.current { background: var(--aksen); color: #fff; border-color: var(--aksen); }
+.stepper-check { display: none; }
+.stepper-circle.done .stepper-num { display: none; }
+.stepper-circle.done .stepper-check { display: inline-flex; }
+.stepper-label { font-size: 13px; font-weight: 600; color: var(--muted3); white-space: nowrap; }
+.stepper-label.current { font-weight: 800; color: var(--ink); }
+.stepper-label.done { color: var(--muted); }
+.stepper-line { flex: 1; height: 2px; background: var(--border); margin: 0 12px; border-radius: 1px; }
+.stepper-line.done { background: var(--aksen); }
+
+.sr-checkbox {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+
+.wizard-progress { height: 6px; background: #E9EDF5; border-radius: 3px; overflow: hidden; margin-bottom: 18px; }
+.wizard-progress-fill { height: 100%; background: var(--aksen); border-radius: 3px; transition: width .25s ease; }
+
+.dropzone {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px;
+  border: 2px dashed var(--aksen-line); border-radius: 16px; padding: 40px 20px; cursor: pointer;
+  background: var(--aksen-tint); text-align: center; transition: border-color .15s ease;
+}
+.dropzone:hover { border-color: var(--aksen); }
+.dropzone-icon {
+  width: 48px; height: 48px; border-radius: 14px; background: #fff; color: var(--aksen);
+  display: flex; align-items: center; justify-content: center; box-shadow: 0 6px 16px -6px var(--aksen-line);
+}
+
+.file-card { display: flex; align-items: center; gap: 14px; border: 1.5px solid var(--border); border-radius: 14px; padding: 14px 16px; background: #FBFCFE; }
+.file-card-icon { width: 42px; height: 42px; border-radius: 12px; background: var(--danger-bg); color: var(--danger); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+
+.check-row {
+  display: flex; align-items: center; gap: 12px; padding: 11px 13px; border: 1.5px solid var(--border3);
+  background: #fff; border-radius: 14px; cursor: pointer; transition: all .12s ease;
+}
+.check-row:hover { border-color: var(--aksen); }
+.check-row.checked { border-color: var(--aksen); background: var(--aksen-tint); }
+.check-box {
+  width: 20px; height: 20px; border-radius: 6px; border: 2px solid #C9D2E2; background: #fff;
+  display: flex; align-items: center; justify-content: center; color: #fff; flex-shrink: 0; transition: all .12s ease;
+}
+.check-box svg { width: 12px; height: 12px; display: none; }
+.check-row.checked .check-box { border-color: var(--aksen); background: var(--aksen); }
+.check-row.checked .check-box svg { display: block; }
+
+.info-box {
+  display: flex; gap: 8px; align-items: flex-start; font-size: 12.5px; color: var(--muted); background: #F5F7FC;
+  border-radius: 10px; padding: 10px 14px; line-height: 1.5;
+}
+.warn-box {
+  display: flex; gap: 10px; align-items: flex-start; font-size: 13px; color: var(--warning-ink); background: var(--warning-bg);
+  border-radius: 12px; padding: 12px 16px; line-height: 1.55;
+}
+.err-box {
+  display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--danger); background: var(--danger-bg);
+  border-radius: 10px; padding: 10px 14px;
+}
+
+.review-block { border: 1.5px solid var(--border3); border-radius: 14px; padding: 16px 18px; }
+.review-block-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
+
+.success-panel {
+  padding: 40px 32px; display: flex; flex-direction: column; align-items: center; text-align: center; gap: 8px;
+}
+.success-icon {
+  width: 76px; height: 76px; border-radius: 999px; background: var(--success-bg); color: var(--success);
+  display: flex; align-items: center; justify-content: center; margin-bottom: 10px;
+}
+.success-icon svg { width: 36px; height: 36px; }
+
+/* ---------- utility ---------- */
+.flex { display: flex; }
+.flex-col { display: flex; flex-direction: column; }
+.gap-4 { gap: 4px; } .gap-6 { gap: 6px; } .gap-8 { gap: 8px; } .gap-10 { gap: 10px; } .gap-12 { gap: 12px; } .gap-14 { gap: 14px; } .gap-16 { gap: 16px; } .gap-20 { gap: 20px; }
+.items-center { align-items: center; }
+.justify-between { justify-content: space-between; }
+.flex-wrap { flex-wrap: wrap; }
+.text-muted { color: var(--muted); }
+.text-muted2 { color: var(--muted2); }
+.text-success { color: var(--success); }
+.fw-700 { font-weight: 700; } .fw-800 { font-weight: 800; }

--- a/public/js/staff-app.js
+++ b/public/js/staff-app.js
@@ -1,0 +1,17 @@
+// Generic expand/collapse handler shared by Beranda team cards and PTATK rows.
+// Any element with [data-toggle-target="<id>"] toggles the [hidden] attribute
+// of the element with that id, and rotates a sibling `.chevron` (if present).
+document.addEventListener('click', function (e) {
+  const trigger = e.target.closest('[data-toggle-target]');
+  if (!trigger) return;
+
+  const target = document.getElementById(trigger.dataset.toggleTarget);
+  if (!target) return;
+
+  const nowHidden = !target.hasAttribute('hidden');
+  target.toggleAttribute('hidden', nowHidden);
+  trigger.setAttribute('aria-expanded', String(!nowHidden));
+
+  const chevron = trigger.querySelector('.chevron');
+  if (chevron) chevron.classList.toggle('open', !nowHidden);
+});

--- a/resources/views/auth.blade.php
+++ b/resources/views/auth.blade.php
@@ -1,89 +1,106 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="id">
 
 <head>
     <meta charset="UTF-8">
-    <title>Login</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Masuk — Anugerah ASN</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ asset('css/staff-app.css') }}">
+
     <style>
-        body {
-            background: linear-gradient(135deg, #6B73FF 0%, #000DFF 100%);
+        body.login-body {
+            min-height: 100vh; display: flex; flex-direction: column; align-items: center; justify-content: center;
+            padding: 24px;
+            background: radial-gradient(1200px 600px at 50% -10%, #3562E314, transparent 60%), var(--bg);
         }
-
-        .card {
-            border-radius: 15px;
+        .login-card {
+            width: 100%; max-width: 400px; background: #fff; border-radius: 24px; padding: 36px 32px;
+            box-shadow: var(--shadow-card);
         }
-
-        .input-group-text {
-            background-color: #f0f0f0;
-            border: none;
+        .login-header { display: flex; flex-direction: column; align-items: center; gap: 10px; margin-bottom: 26px; }
+        .login-logo {
+            width: 52px; height: 52px; border-radius: 14px; background: var(--aksen); color: #fff;
+            display: flex; align-items: center; justify-content: center; font-size: 24px; font-weight: 800;
         }
-
-        .form-control:focus {
-            box-shadow: none;
-            border-color: #6B73FF;
+        .login-title { font-size: 21px; font-weight: 800; letter-spacing: -0.2px; }
+        .login-subtitle { font-size: 13.5px; color: var(--muted); text-align: center; line-height: 1.5; }
+        .pw-wrap { position: relative; }
+        .pw-toggle {
+            position: absolute; right: 6px; top: 5px; width: 36px; height: 36px; border: none; background: transparent;
+            border-radius: 10px; cursor: pointer; color: var(--muted2); display: flex; align-items: center; justify-content: center;
         }
-
-        .btn-primary {
-            background: #6B73FF;
-            border: none;
-        }
-
-        .btn-primary:hover {
-            background: #000DFF;
-        }
+        .pw-toggle:hover { background: #F0F3F9; color: var(--ink); }
+        .remember-label { display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 13.5px; color: var(--muted); user-select: none; }
+        .remember-label input { width: 16px; height: 16px; accent-color: var(--aksen); }
+        .login-footnote { font-size: 12.5px; color: var(--muted2); text-align: center; }
+        .login-copyright { margin-top: 22px; font-size: 12px; color: var(--muted3); }
     </style>
 </head>
 
-<body class="d-flex justify-content-center align-items-center min-vh-100">
-    <div class="card shadow p-5" style="width: 100%; max-width: 400px;">
-        <h3 class="mb-4 text-center text-dark fw-bold">Login</h3>
+<body class="staff-app login-body">
+    <div class="login-card">
+        <div class="login-header">
+            <div class="login-logo">A</div>
+            <div class="login-title">Anugerah ASN</div>
+            <div class="login-subtitle">Sistem pengelolaan tim &amp; honorarium ASN.<br>Masuk dengan akun kepegawaian Anda.</div>
+        </div>
+
+        @if ($errors->has('login'))
+            <div class="err-box" style="margin-bottom: 16px;">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.7 3.86a2 2 0 0 0-3.4 0Z"></path><path d="M12 9v4"></path><path d="M12 17h.01"></path></svg>
+                {{ $errors->first('login') }}
+            </div>
+        @endif
+
         <form method="POST" action="{{ route('login') }}">
             @csrf
-
-            <!-- NIP -->
-            <div class="mb-3">
-                <label for="nip" class="form-label text-dark">NIP</label>
-                <div class="input-group">
-                    <span class="input-group-text"><i class="bi bi-person-fill"></i></span>
-                    <input type="text" class="form-control @error('nip') is-invalid @enderror" id="nip"
-                        name="nip" value="{{ old('nip') }}" required autofocus placeholder="Masukkan NIP">
+            <div class="flex-col gap-16">
+                <div class="flex-col gap-6">
+                    <label for="nip" class="field-label">NIP</label>
+                    <input id="nip" name="nip" type="text" class="input" value="{{ old('nip') }}" required autofocus
+                        placeholder="18 digit NIP">
                     @error('nip')
-                        <div class="invalid-feedback">
-                            {{ $message }}
-                        </div>
+                        <div class="err-box">{{ $message }}</div>
                     @enderror
                 </div>
-            </div>
 
-            <!-- Password -->
-            <div class="mb-3">
-                <label for="password" class="form-label text-dark">Password</label>
-                <div class="input-group">
-                    <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
-                    <input type="password" class="form-control @error('password') is-invalid @enderror" id="password"
-                        name="password" required placeholder="Masukkan password">
+                <div class="flex-col gap-6">
+                    <label for="password" class="field-label">Kata Sandi</label>
+                    <div class="pw-wrap">
+                        <input id="password" name="password" type="password" class="input" style="padding-right: 44px;"
+                            required placeholder="Kata sandi Anda">
+                        <button type="button" class="pw-toggle" id="pwToggle" aria-label="Tampilkan kata sandi">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"></path><circle cx="12" cy="12" r="3"></circle></svg>
+                        </button>
+                    </div>
                     @error('password')
-                        <div class="invalid-feedback">
-                            {{ $message }}
-                        </div>
+                        <div class="err-box">{{ $message }}</div>
                     @enderror
                 </div>
-            </div>
 
-            <!-- Remember me -->
-            <div class="mb-4 form-check">
-                <input type="checkbox" class="form-check-input" id="remember" name="remember"
-                    {{ old('remember') ? 'checked' : '' }}>
-                <label class="form-check-label text-dark" for="remember">Remember me</label>
-            </div>
+                <label for="remember" class="remember-label">
+                    <input id="remember" type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}>
+                    Ingat saya di perangkat ini
+                </label>
 
-            <button type="submit" class="btn btn-primary w-100 py-2 fw-bold">Login</button>
+                <button type="submit" class="btn btn-primary" style="height: 48px; width: 100%; font-size: 15px;">Masuk</button>
+                <div class="login-footnote">Lupa kata sandi? Hubungi admin kepegawaian.</div>
+            </div>
         </form>
     </div>
+    <div class="login-copyright">© {{ date('Y') }} Anugerah ASN</div>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        document.getElementById('pwToggle').addEventListener('click', function () {
+            const input = document.getElementById('password');
+            const showing = input.type === 'text';
+            input.type = showing ? 'password' : 'text';
+        });
+    </script>
 </body>
 
 </html>

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -1,141 +1,70 @@
 @php
     use Illuminate\Support\Facades\Auth;
+
+    $isBeranda = request()->routeIs('staff.dashboard.index');
+    $isPtatk = request()->routeIs('staff.tim.index');
+    $isBuat = request()->routeIs('staff.tim.create');
+    $isProfil = request()->routeIs('staff.profile.index');
 @endphp
 
-<!-- Navbar -->
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark shadow-sm">
-    <div class="container">
-        <!-- Logo -->
-        <a class="navbar-brand fw-bold text-white fs-4" href="{{ route('staff.dashboard.index') }}">Anugerah ASN</a>
+<header class="staff-topbar">
+    <div class="staff-topbar-inner">
+        <a href="{{ route('staff.dashboard.index') }}" class="staff-logo">
+            <div class="staff-logo-mark">A</div>
+            <div class="staff-logo-text">Anugerah ASN</div>
+        </a>
 
-        <!-- Toggle button (mobile) -->
-        <button class="navbar-toggler border-0" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
-            aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
+        {{-- Desktop nav --}}
+        <div class="staff-desktop-only" style="align-items: center; flex: 1; gap: 20px;">
+            <nav aria-label="Navigasi utama" class="staff-nav">
+                <a href="{{ route('staff.dashboard.index') }}" class="staff-nav-item {{ $isBeranda || $isBuat ? 'active' : '' }}">Beranda</a>
+                <a href="{{ route('staff.tim.index') }}" class="staff-nav-item {{ $isPtatk ? 'active' : '' }}">PTATK</a>
+                <a href="{{ route('staff.profile.index') }}" class="staff-nav-item {{ $isProfil ? 'active' : '' }}">Profil</a>
+            </nav>
+            <div class="staff-spacer"></div>
+            <a href="{{ route('staff.tim.create') }}" class="btn btn-primary">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"></path></svg>
+                Buat Tim
+            </a>
+            <div class="staff-divider-v"></div>
+            <a href="{{ route('staff.profile.index') }}" title="Profil saya" class="staff-profile-btn">
+                <div class="avatar avatar-34">{{ Auth::user()->initials }}</div>
+                <div>
+                    <div class="staff-profile-name">{{ Auth::user()->name }}</div>
+                    <div class="staff-profile-role">{{ Auth::user()->jabatan->name ?? '-' }}</div>
+                </div>
+            </a>
+            <form action="{{ route('logout') }}" method="POST" class="m-0">
+                @csrf
+                <button type="submit" class="btn-icon" title="Keluar" aria-label="Keluar">
+                    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="M16 17l5-5-5-5"></path><path d="M21 12H9"></path></svg>
+                </button>
+            </form>
+        </div>
 
-        <!-- Navbar Menu -->
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav mx-auto mb-2 mb-lg-0">
-                <li class="nav-item">
-                    <a class="nav-link fw-medium {{ request()->is('staff/dashboard*') ? 'active' : '' }}" href="{{ route('staff.dashboard.index') }}">
-                        Beranda
-                    </a>
-                </li>
-                {{-- <li class="nav-item">
-                    <a class="nav-link fw-medium {{ request()->is('staff/profile*') ? 'active' : '' }}" href="{{ route('staff.profile.index') }}">
-                        Profil
-                    </a>
-                </li> --}}
-                <li class="nav-item">
-                    <a class="nav-link fw-medium {{ request()->is('staff/tim*') ? 'active' : '' }}" href="{{ route('staff.tim.index') }}">
-                        PTATK
-                    </a>
-                </li>
-            </ul>
-
-            <!-- Auth Buttons -->
-            <div class="d-flex align-items-center">
-                @auth
-                    <span class="mx-auto p-2 text-white">
-                        Halo, <strong>{{ Auth::user()->name }}</strong>
-                    </span>
-                    <form action="{{ route('logout') }}" method="POST" class="m-0">
-                        @csrf
-                        <button type="submit" class="btn btn-light btn-sm ms-2">
-                            Logout
-                        </button>
-                    </form>
-                @else
-                    <a href="{{ route('login') }}" class="btn btn-primary btn-sm">
-                        Login
-                    </a>
-                @endauth
-            </div>
+        {{-- Mobile: spacer + avatar --}}
+        <div class="staff-mobile-only" style="flex: 1; justify-content: flex-end; align-items: center;">
+            <a href="{{ route('staff.profile.index') }}" aria-label="Profil saya">
+                <div class="avatar avatar-36">{{ Auth::user()->initials }}</div>
+            </a>
         </div>
     </div>
+</header>
+
+{{-- Bottom nav (mobile only) --}}
+<nav aria-label="Navigasi bawah" class="staff-bottomnav">
+    <a href="{{ route('staff.dashboard.index') }}" class="staff-bottomnav-item {{ $isBeranda ? 'active' : '' }}">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><path d="M9 22V12h6v10"></path></svg>
+        <span class="staff-bottomnav-label">Beranda</span>
+    </a>
+    <a href="{{ route('staff.tim.create') }}" aria-label="Buat Tim" class="staff-bottomnav-item staff-bottomnav-fab-wrap {{ $isBuat ? 'active' : '' }}">
+        <div class="staff-bottomnav-fab">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"></path></svg>
+        </div>
+        <span class="staff-bottomnav-label">Buat Tim</span>
+    </a>
+    <a href="{{ route('staff.tim.index') }}" class="staff-bottomnav-item {{ $isPtatk ? 'active' : '' }}">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M22 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg>
+        <span class="staff-bottomnav-label">PTATK</span>
+    </a>
 </nav>
-
-<!-- Bottom Navigation (mobile only) -->
-<nav class="staff-bottom-nav d-lg-none fixed-bottom bg-dark border-top border-secondary">
-    <div class="d-flex justify-content-around align-items-stretch">
-        <a href="{{ route('staff.dashboard.index') }}"
-            class="bottom-nav-link {{ request()->is('staff/dashboard*') ? 'active' : '' }}">
-            <i class="bi bi-house-door-fill"></i>
-            <span>Beranda</span>
-        </a>
-        <a href="{{ route('staff.tim.create') }}" class="bottom-nav-link bottom-nav-fab">
-            <span class="bottom-nav-fab-circle"><i class="bi bi-plus-lg"></i></span>
-            <span>Buat Tim</span>
-        </a>
-        <a href="{{ route('staff.tim.index') }}"
-            class="bottom-nav-link {{ request()->is('staff/tim') || request()->is('staff/tim/*') && !request()->is('staff/tim/create') ? 'active' : '' }}">
-            <i class="bi bi-people-fill"></i>
-            <span>Tim</span>
-        </a>
-    </div>
-</nav>
-
-<!-- Custom CSS -->
-<style>
-    .nav-link.active {
-        color: #ffffff !important; /* Biru bootstrap */
-        font-weight: 600;
-        border-bottom: 2px solid #fff;
-    }
-    .navbar-nav .nav-link:hover {
-        color: #fff !important;
-    }
-
-    /* ===== Bottom navigation (mobile) ===== */
-    .staff-bottom-nav {
-        z-index: 1030;
-        box-shadow: 0 -0.25rem 0.75rem rgba(0, 0, 0, 0.15);
-    }
-    .staff-bottom-nav .bottom-nav-link {
-        flex: 1 1 0;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        gap: 2px;
-        padding: 8px 4px;
-        min-height: 60px;
-        color: rgba(255, 255, 255, 0.65);
-        text-decoration: none;
-        font-size: 0.72rem;
-        line-height: 1.1;
-        transition: color .15s ease-in-out;
-    }
-    .staff-bottom-nav .bottom-nav-link i {
-        font-size: 1.25rem;
-    }
-    .staff-bottom-nav .bottom-nav-link.active,
-    .staff-bottom-nav .bottom-nav-link:active {
-        color: #fff;
-    }
-    /* Tombol tengah menonjol (FAB style) */
-    .staff-bottom-nav .bottom-nav-fab {
-        color: #fff;
-    }
-    .staff-bottom-nav .bottom-nav-fab-circle {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 44px;
-        height: 44px;
-        margin-top: -22px;
-        border-radius: 50%;
-        background-color: #0d6efd;
-        box-shadow: 0 0.25rem 0.6rem rgba(13, 110, 253, 0.5);
-    }
-    .staff-bottom-nav .bottom-nav-fab-circle i {
-        font-size: 1.35rem;
-    }
-    /* Beri ruang di bawah konten agar tidak tertutup bottom-nav */
-    @media (max-width: 991.98px) {
-        body {
-            padding-bottom: 72px;
-        }
-    }
-</style>

--- a/resources/views/components/staff-layout.blade.php
+++ b/resources/views/components/staff-layout.blade.php
@@ -1,44 +1,28 @@
 <!doctype html>
-<html lang="en">
+<html lang="id">
 
 <head>
-    <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- Bootstrap 5 CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-    <!-- Bootstrap Icons (global untuk semua halaman staff) -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
-
-    <!-- Select2 CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
-    <link href="https://cdn.jsdelivr.net/npm/select2-bootstrap-5-theme@1.3.0/dist/select2-bootstrap-5-theme.min.css"
-        rel="stylesheet" />
+    <link rel="stylesheet" href="{{ asset('css/staff-app.css') }}">
 
     @stack('styles')
-    <title>Staff</title>
+    <title>Staff — Anugerah ASN</title>
 </head>
 
-<body>
+<body class="staff-app">
     <x-navbar></x-navbar>
 
-    {{-- content --}}
-    <div>{{ $slot }}</div>
+    <main class="staff-main">
+        {{ $slot }}
+    </main>
 
-    {{-- footer --}}
-    <x-footer></x-footer>
-
-    <!-- jQuery -->
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-
-    <!-- Bootstrap 5 Bundle -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-
-    <!-- Select2 JS -->
-    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
-
+    <script src="{{ asset('js/staff-app.js') }}"></script>
     @stack('scripts')
 </body>
 

--- a/resources/views/staff/index.blade.php
+++ b/resources/views/staff/index.blade.php
@@ -1,495 +1,189 @@
 <x-staff-layout>
+    @php
+        $statusMeta = [
+            'approved' => ['label' => 'Disetujui', 'fg' => '#17915F', 'bg' => '#E4F5EE'],
+            'pending'  => ['label' => 'Menunggu Persetujuan', 'fg' => '#B96E00', 'bg' => '#FBF0DC'],
+            'rejected' => ['label' => 'Ditolak', 'fg' => '#D14343', 'bg' => '#FBEAEA'],
+        ];
+        $honorColor = [
+            \App\Services\HonorService::DIBAYAR                => ['fg' => '#17915F', 'bg' => '#E4F5EE'],
+            \App\Services\HonorService::TIDAK_DIBAYAR           => ['fg' => '#5C6B85', 'bg' => '#EDF0F7'],
+            \App\Services\HonorService::PREDIKSI_DIBAYAR        => ['fg' => '#3562E3', 'bg' => '#3562E314'],
+            \App\Services\HonorService::PREDIKSI_TIDAK_DIBAYAR  => ['fg' => '#5C6B85', 'bg' => '#EDF0F7'],
+        ];
+        $today = \Illuminate\Support\Carbon::now()->locale('id')->translatedFormat('l, d F Y');
+        $firstName = explode(' ', $user->name)[0];
 
-    <div class="container py-4">
-        <h2 class="mb-4 fw-bold text-primary">Dashboard Staff</h2>
+        $countHonor = $tims->filter(fn ($t) => ($statusHonorPerTim[$user->id][$t->id]['status'] ?? null) === \App\Services\HonorService::DIBAYAR)->count();
+        $countMenunggu = $tims->where('status', 'pending')->count();
+        $countDitolak = $tims->where('status', 'rejected')->count();
+    @endphp
 
-        {{-- Statistik Cards --}}
-        <div class="row g-3 mb-4">
-            <div class="col-md-4">
-                <div class="card text-center shadow-sm h-100 border-0 rounded-3">
-                    <div class="card-body p-3 d-flex flex-column justify-content-center align-items-center">
-                        <i class="bi bi-people-fill text-primary fs-3 mb-2"></i>
-                        <p class="text-muted mb-1 fs-6">Jumlah Tim Anda</p>
-                        <h4 class="fw-bold mb-0 text-dark">{{ $totalTim }} Tim</h4>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-md-4">
-                <div class="card text-center shadow-sm h-100 border-0 rounded-3">
-                    <div class="card-body p-3 d-flex flex-column justify-content-center align-items-center">
-                        <i class="bi bi-currency-dollar text-success fs-3 mb-2"></i>
-                        <p class="text-muted mb-1 fs-6">Honor Diterima</p>
-                        <h4 class="fw-bold mb-0 text-dark">{{ $totalTim }}/{{ $maksHonor }} Honor</h4>
-
-                        @if ($totalTim > $maksHonor)
-                            <div class="alert alert-warning p-2 mt-3 mb-0 rounded-3" role="alert">
-                                <small class="d-flex align-items-center justify-content-center">
-                                    <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                                    Anda telah melebihi batas maksimal honorarium ({{ $maksHonor }}). Honor
-                                    berikutnya tidak bisa diterima.
-                                </small>
-                            </div>
-                        @endif
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-md-4">
-                <div class="card text-center shadow-sm h-100 border-0 rounded-3">
-                    <div class="card-body p-3 d-flex flex-column justify-content-center align-items-center">
-                        <i class="bi bi-calendar-check-fill text-info fs-3 mb-2"></i>
-                        <p class="text-muted mb-1 fs-6">Diperbarui Pada</p>
-                        <h4 class="fw-bold mb-0 text-dark">
-                            {{ \Carbon\Carbon::parse($user->created_at)->translatedFormat('d F Y') }}
-                        </h4>
-                    </div>
-                </div>
+    <div class="flex-col gap-20">
+        <div class="flex items-center justify-between gap-16 flex-wrap">
+            <div>
+                <h1 class="h1-page">Selamat datang, {{ $firstName }}</h1>
+                <div class="sub-page">{{ $today }}</div>
             </div>
         </div>
 
-        <div class="row g-4 mt-4">
-            {{-- Data Diri Anda Card --}}
-            <div class="col-lg-4">
-                <div class="card shadow-sm h-100 border-0 rounded-3">
-                    <div class="card-body p-4">
-                        <h5 class="fw-bold mb-3 text-primary d-flex align-items-center">
-                            <i class="bi bi-person-circle me-2"></i>Data Diri Anda
-                        </h5>
-                        <p class="mb-2"><strong>Nama:</strong> {{ $user->name }}</p>
-                        <p class="mb-2"><strong>NIP:</strong> {{ $user->nip }}</p>
-                        <p class="mb-3"><strong>Jabatan:</strong> {{ $user->jabatan->name }}</p>
-
-                        <h6 class="fw-semibold mb-2 text-secondary d-flex align-items-center">
-                            <i class="bi bi-cash-coin me-2"></i>Jatah Penerimaan Honorarium
-                        </h6>
-
-                        @php
-                            $actualHonorCount = $ringkasanDiri['jumlah_dibayar'];
-                            $totalTimApproved = $ringkasanDiri['jumlah_tim_approved'];
-                            $progress = $maksHonor > 0 ? min(100, ($actualHonorCount / $maksHonor) * 100) : 0;
-                        @endphp
-
-                        <div class="progress mb-3" style="height: 25px;">
-                            <div class="progress-bar {{ $totalTimApproved > $maksHonor ? 'bg-warning text-dark' : ($actualHonorCount == $maksHonor ? 'bg-success' : 'bg-primary') }}"
-                                role="progressbar" style="width: {{ $progress }}%;"
-                                aria-valuenow="{{ $progress }}" aria-valuemin="0" aria-valuemax="100">
-                                <span class="fw-bold">{{ $actualHonorCount }} / {{ $maksHonor }} Honor</span>
-                            </div>
-                        </div>
-
-                        @if ($totalTimApproved > $maksHonor)
-                            <div class="alert alert-warning p-2 mb-0 rounded-3" role="alert">
-                                <small class="d-flex align-items-center">
-                                    <i class="bi bi-info-circle-fill me-2"></i>
-                                    Anda memiliki {{ $totalTimApproved }} tim approved, tetapi hanya menerima honor
-                                    dari {{ $actualHonorCount }} tim pertama (berdasarkan waktu persetujuan).
-                                </small>
-                            </div>
-                        @elseif ($actualHonorCount == $maksHonor)
-                            <div class="alert alert-success p-2 mb-0 rounded-3" role="alert">
-                                <small class="d-flex align-items-center">
-                                    <i class="bi bi-check-circle-fill me-2"></i>
-                                    Anda telah mencapai batas maksimal honorarium ({{ $maksHonor }}).
-                                </small>
-                            </div>
-                        @endif
+        {{-- Kuota hero --}}
+        <section aria-label="Kuota honorarium" class="card" style="padding: 22px 24px; display: flex; gap: 28px; align-items: stretch; flex-wrap: wrap;">
+            <div style="flex: 1 1 320px; min-width: 260px;">
+                <div style="font-size: 12px; font-weight: 800; letter-spacing: .8px; color: var(--muted2); margin-bottom: 14px;">
+                    KUOTA HONORARIUM {{ $tahunBerjalan }}
+                </div>
+                @if ($maksHonor > 0)
+                    <div class="flex gap-8" style="margin-bottom: 12px;">
+                        @for ($i = 0; $i < $maksHonor; $i++)
+                            <div class="slot-bar {{ $i < $ringkasanDiri['jumlah_dibayar'] ? 'filled' : '' }}"></div>
+                        @endfor
                     </div>
+                    <div style="font-size: 15px; font-weight: 700;">
+                        {{ $ringkasanDiri['jumlah_dibayar'] }} dari {{ $maksHonor }} kuota terpakai
+                        <span style="font-weight: 500; color: var(--muted);">· sisa {{ $ringkasanDiri['sisa_slot'] }} slot</span>
+                    </div>
+                    <div class="field-hint" style="margin-top: 6px; line-height: 1.5;">
+                        Honor dibayarkan maksimal {{ $maksHonor }} tim per tahun sesuai ketentuan jabatan Anda.
+                    </div>
+                @else
+                    <div class="text-muted" style="font-size: 13.5px;">Belum ada informasi kuota honor untuk jabatan Anda.</div>
+                @endif
+            </div>
+            <div style="width: 1px; background: var(--border3);"></div>
+            <div style="flex: 0 1 260px; min-width: 220px; display: flex; flex-direction: column; justify-content: center; gap: 10px;">
+                <div class="flex justify-between" style="font-size: 13.5px;"><span class="text-muted">Tim disetujui</span><strong>{{ $ringkasanDiri['jumlah_tim_approved'] }}</strong></div>
+                <div class="flex justify-between" style="font-size: 13.5px;"><span class="text-muted">Menunggu persetujuan</span><strong>{{ $countMenunggu }}</strong></div>
+                <div class="flex justify-between" style="font-size: 13.5px;"><span class="text-muted">Total honor diterima</span><strong class="text-success">Rp {{ number_format($ringkasanDiri['total_honor'], 0, ',', '.') }}</strong></div>
+                <a href="{{ route('staff.tim.index') }}" class="btn-link flex items-center gap-6" style="margin-top: 4px;">
+                    Lihat riwayat lengkap
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"></path></svg>
+                </a>
+            </div>
+        </section>
+
+        {{-- Tim Anda --}}
+        <section aria-label="Tim Anda" class="flex-col gap-14">
+            <div class="flex items-center justify-between gap-12 flex-wrap">
+                <h2 style="margin: 0; font-size: 17px; font-weight: 800;">Tim Anda — {{ $tahunBerjalan }}</h2>
+                <div style="position: relative; flex: 0 1 280px; min-width: 200px;">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#8B99B3" stroke-width="2" stroke-linecap="round" style="position: absolute; left: 12px; top: 11px;"><circle cx="11" cy="11" r="7"></circle><path d="m21 21-4.3-4.3"></path></svg>
+                    <input type="text" id="berandaSearch" class="input input-pill" placeholder="Cari nama tim…" aria-label="Cari tim">
                 </div>
             </div>
 
-            {{-- Daftar Tim Card --}}
-            <div class="col-lg-8">
-                <div class="card shadow-sm h-100 border-0 rounded-3">
-                    <div class="card-body p-4">
-                        <div class="d-flex justify-content-between align-items-center mb-3">
-                            <h5 class="fw-bold mb-0 text-primary d-flex align-items-center">
-                                <i class="bi bi-list-task me-2"></i>Daftar Tim Anda
-                            </h5>
-                            <a href="{{ route('staff.tim.create') }}" class="btn btn-primary btn-sm rounded-pill px-3">
-                                <i class="bi bi-plus-circle me-1"></i>Buat Tim
-                            </a>
-                        </div>
-                        <div class="mb-3">
-                            <input type="text" class="form-control rounded-pill" placeholder="Cari Tim..."
-                                id="searchTim">
-                        </div>
+            <div class="flex gap-8 flex-wrap" id="berandaChips">
+                <button type="button" class="chip active" data-chip="semua">Semua ({{ $tims->count() }})</button>
+                <button type="button" class="chip" data-chip="honor">Dapat Honor ({{ $countHonor }})</button>
+                <button type="button" class="chip" data-chip="menunggu">Menunggu ({{ $countMenunggu }})</button>
+                <button type="button" class="chip" data-chip="ditolak">Ditolak ({{ $countDitolak }})</button>
+            </div>
 
-                        @if ($tims->isEmpty())
-                            <div class="alert alert-info text-center mt-4 rounded-3" role="alert">
-                                <i class="bi bi-info-circle-fill me-2"></i>Belum ada tim yang terdaftar.
+            <div class="flex-col gap-10" id="berandaList">
+                @forelse ($tims as $tim)
+                    @php
+                        $sm = $statusMeta[$tim->status];
+                        $mine = $statusHonorPerTim[$user->id][$tim->id] ?? null;
+                        $hc = $mine ? $honorColor[$mine['status']] : null;
+                        $filters = ['semua'];
+                        if ($mine && $mine['status'] === \App\Services\HonorService::DIBAYAR) $filters[] = 'honor';
+                        if ($tim->status === 'pending') $filters[] = 'menunggu';
+                        if ($tim->status === 'rejected') $filters[] = 'ditolak';
+                    @endphp
+                    <article class="card card-sm team-card" data-name="{{ mb_strtolower($tim->nama_tim) }}" data-filters="{{ implode(' ', $filters) }}">
+                        <button type="button" class="team-card-head" data-toggle-target="team-body-{{ $tim->id }}" aria-expanded="false">
+                            <div class="team-card-icon" style="background: {{ $sm['bg'] }}; color: {{ $sm['fg'] }};">
+                                @if ($tim->status === 'approved')
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M22 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg>
+                                @elseif ($tim->status === 'pending')
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v5l3 3"></path></svg>
+                                @else
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"></circle><path d="m15 9-6 6M9 9l6 6"></path></svg>
+                                @endif
                             </div>
-                        @else
-                            {{-- BAGIAN 1: TIM YANG MENDAPAT HONOR --}}
-                            @php
-                                $timsWithHonor = $tims->filter(function ($tim) use ($statusHonorPerTim, $user) {
-                                    return isset($statusHonorPerTim[$user->id][$tim->id]) &&
-                                        $statusHonorPerTim[$user->id][$tim->id] === 'Honor Diterima';
-                                });
-                            @endphp
-
-                            @if ($timsWithHonor->isNotEmpty())
-                                <div class="mb-4">
-                                    <h6 class="fw-bold text-success mb-3 d-flex align-items-center">
-                                        <i class="bi bi-award-fill me-2"></i>Tim yang Menerima Honor
-                                        <span
-                                            class="badge bg-success-subtle text-success ms-2">{{ $timsWithHonor->count() }}</span>
-                                    </h6>
-
-                                    <div class="accordion accordion-flush" id="accordionTimHonor">
-                                        @foreach ($timsWithHonor as $tim)
-                                            <div class="accordion-item mb-2 border border-success rounded-3 shadow-sm">
-                                                <h2 class="accordion-header" id="heading-honor-{{ $tim->id }}">
-                                                    <button
-                                                        class="accordion-button collapsed bg-success-subtle text-success fw-bold rounded-3 p-3"
-                                                        type="button" data-bs-toggle="collapse"
-                                                        data-bs-target="#tim-honor-{{ $tim->id }}"
-                                                        aria-expanded="false"
-                                                        aria-controls="tim-honor-{{ $tim->id }}">
-                                                        <div class="d-flex align-items-center flex-wrap w-100 gap-2">
-                                                            <i class="bi bi-check-circle-fill fs-5"></i>
-                                                            <div class="flex-grow-1">
-                                                                <span class="fs-6">{{ $tim->nama_tim }}</span>
-                                                                <small
-                                                                    class="d-block text-muted">{{ $tim->users->count() }}
-                                                                    Anggota</small>
-                                                            </div>
-                                                            <div class="d-flex gap-2 flex-shrink-0">
-                                                                <span
-                                                                    class="badge bg-success rounded-pill py-2 px-3">Honor
-                                                                    Diterima</span>
-                                                                <span
-                                                                    class="badge {{ $tim->status == 'approved' ? 'bg-success' : ($tim->status == 'pending' ? 'bg-warning text-dark' : 'bg-danger') }} rounded-pill py-2 px-3">
-                                                                    {{ ucfirst($tim->status) }}
-                                                                </span>
-                                                            </div>
-                                                        </div>
-                                                    </button>
-                                                </h2>
-                                                <div id="tim-honor-{{ $tim->id }}"
-                                                    class="accordion-collapse collapse"
-                                                    aria-labelledby="heading-honor-{{ $tim->id }}"
-                                                    data-bs-parent="#accordionTimHonor">
-                                                    <div class="accordion-body p-3 bg-light">
-                                                        @if ($tim->keterangan)
-                                                            <p class="mb-3 text-muted small">{{ $tim->keterangan }}</p>
-                                                        @endif
-                                                        <ul class="list-group list-group-flush">
-                                                            @forelse($tim->users as $anggota)
-                                                                <li
-                                                                    class="list-group-item d-flex justify-content-between align-items-center px-0 py-2 bg-light">
-                                                                    <div class="d-flex align-items-center">
-                                                                        <div class="rounded-circle bg-success text-white d-flex justify-content-center align-items-center me-2"
-                                                                            style="width:32px; height:32px; font-size: 0.8rem;">
-                                                                            {{ strtoupper(substr($anggota->name, 0, 1)) }}
-                                                                        </div>
-                                                                        <div>
-                                                                            <strong
-                                                                                class="d-block">{{ $anggota->name }}</strong>
-                                                                            <small
-                                                                                class="text-muted">{{ $anggota->jabatan->name }}</small>
-                                                                        </div>
-                                                                    </div>
-                                                                    <small class="text-muted">
-                                                                        @if (isset($statusHonorPerTim[$anggota->id][$tim->id]))
-                                                                            @if ($statusHonorPerTim[$anggota->id][$tim->id] === 'Honor Diterima')
-                                                                                <span
-                                                                                    class="badge bg-success">Honor
-                                                                                    Diterima</span>
-                                                                            @else
-                                                                                <span
-                                                                                    class="badge bg-warning text-dark">{{ $statusHonorPerTim[$anggota->id][$tim->id] }}</span>
-                                                                            @endif
-                                                                        @endif
-                                                                    </small>
-                                                                </li>
-                                                            @empty
-                                                                <li
-                                                                    class="list-group-item text-muted px-0 py-2 bg-light">
-                                                                    Belum ada anggota</li>
-                                                            @endforelse
-                                                        </ul>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        @endforeach
+                            <div style="flex: 1; min-width: 180px;">
+                                <div style="font-size: 15px; font-weight: 700; margin-bottom: 3px;">{{ $tim->nama_tim }}</div>
+                                <div class="text-muted2" style="font-size: 12.5px;">{{ $tim->users->count() }} anggota · dibuat {{ $tim->created_at->locale('id')->translatedFormat('d M Y') }}</div>
+                            </div>
+                            <div class="flex gap-8 items-center flex-wrap">
+                                <span class="badge-pill" style="background: {{ $sm['bg'] }}; color: {{ $sm['fg'] }};">{{ $sm['label'] }}</span>
+                                @if ($mine)
+                                    <span class="badge-pill" style="background: {{ $hc['bg'] }}; color: {{ $hc['fg'] }};">{{ $mine['label'] }}</span>
+                                @endif
+                                <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="#8B99B3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"></path></svg>
+                            </div>
+                        </button>
+                        <div id="team-body-{{ $tim->id }}" class="team-card-body" hidden>
+                            <p style="margin: 0 0 14px; font-size: 13.5px; color: var(--muted); line-height: 1.6;">{{ $tim->keterangan }}</p>
+                            <div style="font-size: 12px; font-weight: 800; letter-spacing: .6px; color: var(--muted2); margin-bottom: 10px;">ANGGOTA ({{ $tim->users->count() }})</div>
+                            <div class="flex-col" style="gap: 2px;">
+                                @foreach ($tim->users as $anggota)
+                                    @php
+                                        $mm = $statusHonorPerTim[$anggota->id][$tim->id] ?? null;
+                                        $mc = $mm ? $honorColor[$mm['status']] : null;
+                                    @endphp
+                                    <div class="member-row">
+                                        <div class="avatar avatar-32">{{ $anggota->initials }}</div>
+                                        <div style="flex: 1; min-width: 120px;">
+                                            <div style="font-size: 13.5px; font-weight: 600;">{{ $anggota->name }}{{ $anggota->id === $user->id ? ' (Anda)' : '' }}</div>
+                                            <div class="text-muted2" style="font-size: 12px;">{{ $anggota->jabatan->name ?? '-' }}</div>
+                                        </div>
+                                        @if ($mm)
+                                            <span class="badge-pill" style="background: {{ $mc['bg'] }}; color: {{ $mc['fg'] }};">{{ $mm['label'] }}</span>
+                                        @endif
                                     </div>
-                                </div>
-                            @endif
-
-                            {{-- BAGIAN 2: TIM YANG TIDAK MENDAPAT HONOR LAGI --}}
-                            @php
-                                $timsWithoutHonor = $tims->filter(function ($tim) use ($statusHonorPerTim, $user) {
-                                    return !isset($statusHonorPerTim[$user->id][$tim->id]) ||
-                                        !in_array($statusHonorPerTim[$user->id][$tim->id], [
-                                            'Honor Diterima',
-                                            'Akan menerima honor jika disetujui',
-                                        ]);
-                                });
-                            @endphp
-
-                            @if ($timsWithoutHonor->isNotEmpty())
-                                <div class="mb-4">
-                                    <h6 class="fw-bold text-secondary mb-3 d-flex align-items-center">
-                                        <i class="bi bi-x-circle-fill me-2"></i>Tim Tanpa Honor
-                                        <span
-                                            class="badge bg-secondary-subtle text-secondary ms-2">{{ $timsWithoutHonor->count() }}</span>
-                                    </h6>
-
-                                    <div class="accordion accordion-flush" id="accordionTimNoHonor">
-                                        @foreach ($timsWithoutHonor as $tim)
-                                            <div
-                                                class="accordion-item mb-2 border border-secondary rounded-3 shadow-sm">
-                                                <h2 class="accordion-header"
-                                                    id="heading-no-honor-{{ $tim->id }}">
-                                                    <button
-                                                        class="accordion-button collapsed bg-secondary-subtle text-secondary fw-bold rounded-3 p-3"
-                                                        type="button" data-bs-toggle="collapse"
-                                                        data-bs-target="#tim-no-honor-{{ $tim->id }}"
-                                                        aria-expanded="false"
-                                                        aria-controls="tim-no-honor-{{ $tim->id }}">
-                                                        <div class="d-flex align-items-center flex-wrap w-100 gap-2">
-                                                            <i class="bi bi-dash-circle-fill fs-5"></i>
-                                                            <div class="flex-grow-1">
-                                                                <span class="fs-6">{{ $tim->nama_tim }}</span>
-                                                                <small
-                                                                    class="d-block text-muted">{{ $tim->users->count() }}
-                                                                    Anggota</small>
-                                                            </div>
-                                                            <div class="d-flex gap-2 flex-shrink-0">
-                                                                <span
-                                                                    class="badge bg-secondary rounded-pill py-2 px-3">Tidak
-                                                                    Ada Honor</span>
-                                                                <span
-                                                                    class="badge {{ $tim->status == 'approved' ? 'bg-success' : ($tim->status == 'pending' ? 'bg-warning text-dark' : 'bg-danger') }} rounded-pill py-2 px-3">
-                                                                    {{ ucfirst($tim->status) }}
-                                                                </span>
-                                                            </div>
-                                                        </div>
-                                                    </button>
-                                                </h2>
-                                                <div id="tim-no-honor-{{ $tim->id }}"
-                                                    class="accordion-collapse collapse"
-                                                    aria-labelledby="heading-no-honor-{{ $tim->id }}"
-                                                    data-bs-parent="#accordionTimNoHonor">
-                                                    <div class="accordion-body p-3 bg-light">
-                                                        @if ($tim->keterangan)
-                                                            <p class="mb-3 text-muted small">{{ $tim->keterangan }}
-                                                            </p>
-                                                        @endif
-                                                        <ul class="list-group list-group-flush">
-                                                            @forelse($tim->users as $anggota)
-                                                                <li
-                                                                    class="list-group-item d-flex justify-content-between align-items-center px-0 py-2 bg-light">
-                                                                    <div class="d-flex align-items-center">
-                                                                        <div class="rounded-circle bg-secondary text-white d-flex justify-content-center align-items-center me-2"
-                                                                            style="width:32px; height:32px; font-size: 0.8rem;">
-                                                                            {{ strtoupper(substr($anggota->name, 0, 1)) }}
-                                                                        </div>
-                                                                        <div>
-                                                                            <strong
-                                                                                class="d-block">{{ $anggota->name }}</strong>
-                                                                            <small
-                                                                                class="text-muted">{{ $anggota->jabatan->name }}</small>
-                                                                        </div>
-                                                                    </div>
-                                                                    <small class="text-muted">
-                                                                        @if (isset($statusHonorPerTim[$anggota->id][$tim->id]))
-                                                                            @if ($statusHonorPerTim[$anggota->id][$tim->id] === 'Tidak akan menerima honor')
-                                                                                <span
-                                                                                    class="badge bg-secondary">Tidak
-                                                                                    akan menerima honor</span>
-                                                                            @elseif($statusHonorPerTim[$anggota->id][$tim->id] === 'Tidak menerima honor lagi')
-                                                                                <span
-                                                                                    class="badge bg-warning text-dark">Tidak
-                                                                                    menerima honor lagi</span>
-                                                                            @else
-                                                                                <span
-                                                                                    class="badge bg-info text-white">{{ $statusHonorPerTim[$anggota->id][$tim->id] }}</span>
-                                                                            @endif
-                                                                        @endif
-                                                                    </small>
-                                                                </li>
-                                                            @empty
-                                                                <li
-                                                                    class="list-group-item text-muted px-0 py-2 bg-light">
-                                                                    Belum ada anggota</li>
-                                                            @endforelse
-                                                        </ul>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        @endforeach
-                                    </div>
-                                </div>
-                            @endif
-
-                            {{-- BAGIAN 3: TIM PENDING YANG BERPOTENSI MENDAPAT HONOR --}}
-                            @php
-                                $timsPendingWithHonor = $tims->filter(function ($tim) use ($statusHonorPerTim, $user) {
-                                    return isset($statusHonorPerTim[$user->id][$tim->id]) &&
-                                        $statusHonorPerTim[$user->id][$tim->id] ===
-                                            'Akan menerima honor jika disetujui';
-                                });
-                            @endphp
-
-                            @if ($timsPendingWithHonor->isNotEmpty())
-                                <div class="mb-4">
-                                    <h6 class="fw-bold text-info mb-3 d-flex align-items-center">
-                                        <i class="bi bi-hourglass-split me-2"></i>Tim Pending - Berpotensi Honor
-                                        <span
-                                            class="badge bg-info-subtle text-info ms-2">{{ $timsPendingWithHonor->count() }}</span>
-                                    </h6>
-
-                                    <div class="accordion accordion-flush" id="accordionTimPendingHonor">
-                                        @foreach ($timsPendingWithHonor as $tim)
-                                            <div class="accordion-item mb-2 border border-info rounded-3 shadow-sm">
-                                                <h2 class="accordion-header"
-                                                    id="heading-pending-honor-{{ $tim->id }}">
-                                                    <button
-                                                        class="accordion-button collapsed bg-info-subtle text-info fw-bold rounded-3 p-3"
-                                                        type="button" data-bs-toggle="collapse"
-                                                        data-bs-target="#tim-pending-honor-{{ $tim->id }}"
-                                                        aria-expanded="false"
-                                                        aria-controls="tim-pending-honor-{{ $tim->id }}">
-                                                        <div class="d-flex align-items-center flex-wrap w-100 gap-2">
-                                                            <i class="bi bi-clock-fill fs-5"></i>
-                                                            <div class="flex-grow-1">
-                                                                <span class="fs-6">{{ $tim->nama_tim }}</span>
-                                                                <small
-                                                                    class="d-block text-muted">{{ $tim->users->count() }}
-                                                                    Anggota</small>
-                                                            </div>
-                                                            <div class="d-flex gap-2 flex-shrink-0">
-                                                                <span
-                                                                    class="badge bg-info rounded-pill py-2 px-3">Akan
-                                                                    Dapat Honor</span>
-                                                                <span
-                                                                    class="badge bg-warning text-dark rounded-pill py-2 px-3">Pending</span>
-                                                            </div>
-                                                        </div>
-                                                    </button>
-                                                </h2>
-                                                <div id="tim-pending-honor-{{ $tim->id }}"
-                                                    class="accordion-collapse collapse"
-                                                    aria-labelledby="heading-pending-honor-{{ $tim->id }}"
-                                                    data-bs-parent="#accordionTimPendingHonor">
-                                                    <div class="accordion-body p-3 bg-light">
-                                                        @if ($tim->keterangan)
-                                                            <p class="mb-3 text-muted small">{{ $tim->keterangan }}
-                                                            </p>
-                                                        @endif
-                                                        <ul class="list-group list-group-flush">
-                                                            @forelse($tim->users as $anggota)
-                                                                <li
-                                                                    class="list-group-item d-flex justify-content-between align-items-center px-0 py-2 bg-light">
-                                                                    <div class="d-flex align-items-center">
-                                                                        <div class="rounded-circle bg-info text-white d-flex justify-content-center align-items-center me-2"
-                                                                            style="width:32px; height:32px; font-size: 0.8rem;">
-                                                                            {{ strtoupper(substr($anggota->name, 0, 1)) }}
-                                                                        </div>
-                                                                        <div>
-                                                                            <strong
-                                                                                class="d-block">{{ $anggota->name }}</strong>
-                                                                            <small
-                                                                                class="text-muted">{{ $anggota->jabatan->name }}</small>
-                                                                        </div>
-                                                                    </div>
-                                                                    <small class="text-muted">
-                                                                        @if (isset($statusHonorPerTim[$anggota->id][$tim->id]))
-                                                                            @if ($statusHonorPerTim[$anggota->id][$tim->id] === 'Akan menerima honor jika disetujui')
-                                                                                <span
-                                                                                    class="badge bg-info text-white">Akan
-                                                                                    menerima honor jika disetujui</span>
-                                                                            @else
-                                                                                <span
-                                                                                    class="badge bg-secondary">{{ $statusHonorPerTim[$anggota->id][$tim->id] }}</span>
-                                                                            @endif
-                                                                        @endif
-                                                                    </small>
-                                                                </li>
-                                                            @empty
-                                                                <li
-                                                                    class="list-group-item text-muted px-0 py-2 bg-light">
-                                                                    Belum ada anggota</li>
-                                                            @endforelse
-                                                        </ul>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        @endforeach
-                                    </div>
-                                </div>
-                            @endif
-                        @endif {{-- End of if ($tims->isEmpty()) --}}
+                                @endforeach
+                            </div>
+                        </div>
+                    </article>
+                @empty
+                    <div class="card" style="padding: 36px; text-align: center; color: var(--muted2); font-size: 14px;">
+                        Belum ada tim yang terdaftar tahun ini.
                     </div>
+                @endforelse
+                <div class="card" id="berandaEmpty" style="padding: 36px; text-align: center; color: var(--muted2); font-size: 14px;" hidden>
+                    Tidak ada tim yang cocok dengan pencarian atau filter.
                 </div>
             </div>
-        </div>
+        </section>
     </div>
 
-    {{-- Script Search Tim --}}
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const searchInput = document.getElementById('searchTim');
-            const accordions = document.querySelectorAll('.accordion-flush'); // Select all accordion containers
+    @push('scripts')
+        <script>
+            (function () {
+                const search = document.getElementById('berandaSearch');
+                const chipsWrap = document.getElementById('berandaChips');
+                const list = document.getElementById('berandaList');
+                const empty = document.getElementById('berandaEmpty');
+                const cards = Array.from(list.querySelectorAll('.team-card'));
+                let activeChip = 'semua';
 
-            searchInput.addEventListener('keyup', function() {
-                let filter = this.value.toLowerCase();
-                let anyTimFound = false;
-
-                accordions.forEach(accordion => {
-                    let accordionItems = accordion.querySelectorAll('.accordion-item');
-                    let accordionHasVisibleItems = false;
-
-                    accordionItems.forEach(item => {
-                        let timNameElement = item.querySelector('.accordion-button .fs-6');
-                        if (timNameElement) {
-                            let timName = timNameElement.textContent.toLowerCase();
-                            if (timName.includes(filter)) {
-                                item.style.display = ''; // Show item
-                                accordionHasVisibleItems = true;
-                                anyTimFound = true;
-                            } else {
-                                item.style.display = 'none'; // Hide item
-                            }
-                        }
+                function applyFilters() {
+                    const q = search.value.trim().toLowerCase();
+                    let visibleCount = 0;
+                    cards.forEach(card => {
+                        const matchesChip = activeChip === 'semua' || card.dataset.filters.split(' ').includes(activeChip);
+                        const matchesSearch = !q || card.dataset.name.includes(q);
+                        const show = matchesChip && matchesSearch;
+                        card.hidden = !show;
+                        if (show) visibleCount++;
                     });
-
-                    // Hide or show the accordion section header if no items are visible
-                    const sectionHeader = accordion
-                        .previousElementSibling; // Assuming header is right before accordion
-                    if (sectionHeader && sectionHeader.tagName === 'H6') {
-                        if (accordionHasVisibleItems) {
-                            sectionHeader.style.display = '';
-                            accordion.style.display = '';
-                        } else {
-                            sectionHeader.style.display = 'none';
-                            accordion.style.display = 'none';
-                        }
-                    }
-                });
-
-                // Handle "Tim tidak ditemukan" message globally
-                let notFoundId = 'tim-not-found-msg';
-                let notFoundElem = document.getElementById(notFoundId);
-                const timListContainer = document.querySelector(
-                    '.col-lg-8 .card-body'); // Adjust selector if needed
-
-                if (!anyTimFound && filter.length > 0) { // Only show if search input is not empty
-                    if (!notFoundElem) {
-                        let msg = document.createElement('p');
-                        msg.id = notFoundId;
-                        msg.className = 'text-muted text-center my-3 fs-5';
-                        msg.innerHTML = '<i class="bi bi-exclamation-circle me-2"></i>Tim tidak ditemukan.';
-                        timListContainer.appendChild(msg);
-                    }
-                } else {
-                    if (notFoundElem) {
-                        notFoundElem.remove();
-                    }
+                    empty.hidden = visibleCount > 0 || cards.length === 0;
                 }
-            });
-        });
-    </script>
+
+                if (search) search.addEventListener('input', applyFilters);
+
+                if (chipsWrap) {
+                    chipsWrap.addEventListener('click', function (e) {
+                        const btn = e.target.closest('.chip');
+                        if (!btn) return;
+                        chipsWrap.querySelectorAll('.chip').forEach(c => c.classList.remove('active'));
+                        btn.classList.add('active');
+                        activeChip = btn.dataset.chip;
+                        applyFilters();
+                    });
+                }
+            })();
+        </script>
+    @endpush
 </x-staff-layout>

--- a/resources/views/staff/partials/profile-card.blade.php
+++ b/resources/views/staff/partials/profile-card.blade.php
@@ -1,0 +1,32 @@
+@php use Illuminate\Support\Facades\Auth; @endphp
+
+<div class="flex items-center gap-16" style="margin-bottom: 20px;">
+    <div class="avatar avatar-62">{{ $user->initials }}</div>
+    <div>
+        <div style="font-size: 18px; font-weight: 800;">{{ $user->name }}</div>
+        <div class="text-muted2" style="font-size: 13px;">NIP {{ $user->nip }}</div>
+    </div>
+</div>
+
+<div class="flex-col" style="gap: 0;">
+    <div class="flex justify-between gap-14" style="padding: 12px 0; border-top: 1px solid var(--border4); font-size: 13.5px;">
+        <span class="text-muted2">Jabatan</span><strong style="text-align: right;">{{ $user->jabatan->name ?? '-' }}</strong>
+    </div>
+    <div class="flex justify-between gap-14" style="padding: 12px 0; border-top: 1px solid var(--border4); font-size: 13.5px;">
+        <span class="text-muted2">Eselon</span><strong>{{ $user->jabatan->eselon->name ?? '-' }}</strong>
+    </div>
+    <div class="flex justify-between gap-14" style="padding: 12px 0; border-top: 1px solid var(--border4); font-size: 13.5px;">
+        <span class="text-muted2">Email</span><strong>{{ $user->email }}</strong>
+    </div>
+    <div class="flex justify-between gap-14" style="padding: 12px 0; border-top: 1px solid var(--border4); font-size: 13.5px;">
+        <span class="text-muted2">Kuota honor / tahun</span><strong>{{ $ringkasan['maks_honor'] }} tim</strong>
+    </div>
+</div>
+
+<form action="{{ route('logout') }}" method="POST" style="margin-top: 18px;">
+    @csrf
+    <button type="submit" class="btn btn-ghost" style="width: 100%; height: 42px; font-size: 13.5px;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><path d="M16 17l5-5-5-5"></path><path d="M21 12H9"></path></svg>
+        Keluar dari Akun
+    </button>
+</form>

--- a/resources/views/staff/partials/profile-honor.blade.php
+++ b/resources/views/staff/partials/profile-honor.blade.php
@@ -1,0 +1,39 @@
+<div style="font-size: 12px; font-weight: 800; letter-spacing: .8px; color: var(--muted2); margin-bottom: 16px;">
+    HONORARIUM TAHUN {{ $ringkasan['tahun'] }}
+</div>
+
+@if ($ringkasan['maks_honor'] > 0)
+    <div class="flex gap-8" style="margin-bottom: 18px;">
+        @for ($i = 0; $i < $ringkasan['maks_honor']; $i++)
+            <div class="slot-bar {{ $i < $ringkasan['jumlah_dibayar'] ? 'filled' : '' }}" style="height: 12px; border-radius: 6px;"></div>
+        @endfor
+    </div>
+@else
+    <div class="text-muted" style="font-size: 13.5px; margin-bottom: 18px;">Belum ada informasi kuota honor untuk jabatan Anda.</div>
+@endif
+
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 12px;">
+    <div style="background: #F7F9FD; border-radius: 14px; padding: 14px 16px;">
+        <div style="font-size: 20px; font-weight: 800;">{{ $ringkasan['jumlah_dibayar'] }}/{{ $ringkasan['maks_honor'] }}</div>
+        <div class="text-muted2" style="font-size: 12px; margin-top: 2px;">Tim dibayar</div>
+    </div>
+    <div style="background: #F7F9FD; border-radius: 14px; padding: 14px 16px;">
+        <div style="font-size: 20px; font-weight: 800;">{{ $ringkasan['jumlah_tim_approved'] }}</div>
+        <div class="text-muted2" style="font-size: 12px; margin-top: 2px;">Tim disetujui</div>
+    </div>
+    <div style="background: #F7F9FD; border-radius: 14px; padding: 14px 16px;">
+        <div style="font-size: 20px; font-weight: 800;">{{ $ringkasan['sisa_slot'] }}</div>
+        <div class="text-muted2" style="font-size: 12px; margin-top: 2px;">Sisa slot</div>
+    </div>
+    <div style="background: var(--success-bg); border-radius: 14px; padding: 14px 16px;">
+        <div style="font-size: 17px; font-weight: 800; color: var(--success);">Rp {{ number_format($ringkasan['total_honor'], 0, ',', '.') }}</div>
+        <div style="font-size: 12px; margin-top: 2px; color: #4B8A6E;">Total honor diterima</div>
+    </div>
+</div>
+
+@if ($ringkasan['is_over_limit'])
+    <div class="warn-box" style="margin-top: 18px;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#B96E00" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0; margin-top: 1px;"><path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.7 3.86a2 2 0 0 0-3.4 0Z"></path><path d="M12 9v4"></path><path d="M12 17h.01"></path></svg>
+        Anda mengikuti {{ $ringkasan['jumlah_tim_approved'] }} tim approved, melebihi kuota {{ $ringkasan['maks_honor'] }}. Tim di luar kuota tidak menerima honor.
+    </div>
+@endif

--- a/resources/views/staff/profile.blade.php
+++ b/resources/views/staff/profile.blade.php
@@ -1,73 +1,23 @@
 <x-staff-layout>
-    <div class="container py-4">
-        <h2 class="mb-4 fw-bold text-primary">Profil Saya</h2>
+    <div class="flex-col gap-20">
+        <h1 class="h1-page">Profil Saya</h1>
 
-        <div class="row g-4">
-            <div class="col-lg-5">
-                <div class="card shadow-sm border-0 rounded-3 h-100">
-                    <div class="card-body p-4">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="rounded-circle bg-primary text-white d-flex align-items-center justify-content-center fs-4 fw-bold me-3"
-                                style="width:60px;height:60px;">
-                                {{ strtoupper(substr($user->name, 0, 1)) }}
-                            </div>
-                            <div>
-                                <h5 class="mb-0 fw-bold">{{ $user->name }}</h5>
-                                <small class="text-muted">NIP. {{ $user->nip }}</small>
-                            </div>
-                        </div>
-                        <hr>
-                        <p class="mb-2"><strong>Email:</strong> {{ $user->email }}</p>
-                        <p class="mb-2"><strong>Jabatan:</strong> {{ $user->jabatan->name }}</p>
-                        <p class="mb-0"><strong>Eselon:</strong> {{ $user->jabatan->eselon->name ?? '-' }}</p>
-                    </div>
-                </div>
-            </div>
+        <div class="profile-grid">
+            <section class="card" style="padding: 26px;">
+                @include('staff.partials.profile-card')
+            </section>
+            <section class="card" style="padding: 26px;">
+                @include('staff.partials.profile-honor')
+            </section>
+        </div>
 
-            <div class="col-lg-7">
-                <div class="card shadow-sm border-0 rounded-3 h-100">
-                    <div class="card-body p-4">
-                        <h5 class="fw-bold text-primary mb-3">
-                            <i class="bi bi-cash-coin me-2"></i>Honor Tahun {{ $ringkasan['tahun'] }}
-                        </h5>
-
-                        <div class="row text-center g-3">
-                            <div class="col-6 col-md-3">
-                                <div class="p-3 bg-light rounded-3">
-                                    <div class="fs-4 fw-bold text-dark">{{ $ringkasan['jumlah_dibayar'] }}/{{ $ringkasan['maks_honor'] }}</div>
-                                    <small class="text-muted">Tim Dibayar</small>
-                                </div>
-                            </div>
-                            <div class="col-6 col-md-3">
-                                <div class="p-3 bg-light rounded-3">
-                                    <div class="fs-4 fw-bold text-dark">{{ $ringkasan['jumlah_tim_approved'] }}</div>
-                                    <small class="text-muted">Total Tim Approved</small>
-                                </div>
-                            </div>
-                            <div class="col-6 col-md-3">
-                                <div class="p-3 bg-light rounded-3">
-                                    <div class="fs-4 fw-bold text-dark">{{ $ringkasan['sisa_slot'] }}</div>
-                                    <small class="text-muted">Sisa Slot</small>
-                                </div>
-                            </div>
-                            <div class="col-6 col-md-3">
-                                <div class="p-3 bg-light rounded-3">
-                                    <div class="fs-6 fw-bold text-success">Rp {{ number_format($ringkasan['total_honor'], 0, ',', '.') }}</div>
-                                    <small class="text-muted">Total Honor</small>
-                                </div>
-                            </div>
-                        </div>
-
-                        @if ($ringkasan['is_over_limit'])
-                            <div class="alert alert-warning mt-4 mb-0 rounded-3">
-                                <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                                Anda mengikuti {{ $ringkasan['jumlah_tim_approved'] }} tim approved, melebihi kuota
-                                {{ $ringkasan['maks_honor'] }}. Tim di luar kuota tidak menerima honor.
-                            </div>
-                        @endif
-                    </div>
-                </div>
-            </div>
+        <div class="staff-mobile-only flex-col gap-16">
+            <section class="card" style="padding: 26px;">
+                @include('staff.partials.profile-card')
+            </section>
+            <section class="card" style="padding: 26px;">
+                @include('staff.partials.profile-honor')
+            </section>
         </div>
     </div>
 </x-staff-layout>

--- a/resources/views/staff/tim/create.blade.php
+++ b/resources/views/staff/tim/create.blade.php
@@ -1,388 +1,453 @@
 <x-staff-layout>
-    @push('styles')
-        {{-- Contoh import font dari Google Fonts --}}
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-        <style>
-            body {
-                font-family: 'Inter', sans-serif;
-                background-color: #f8f9fa; /* Warna latar belakang yang lebih lembut */
-            }
-            .card {
-                border: none; /* Hapus border default */
-                border-radius: 0.75rem; /* Sudut yang lebih membulat */
-                box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.08); /* Shadow yang lebih halus */
-            }
-            .card-header {
-                border-bottom: 1px solid #e9ecef; /* Border bawah yang lebih halus */
-                background-color: #ffffff;
-                border-top-left-radius: 0.75rem;
-                border-top-right-radius: 0.75rem;
-            }
-            .form-label {
-                font-weight: 500; /* Label sedikit lebih tebal */
-                color: #343a40;
-            }
-            .form-control, .select2-container--bootstrap-5 .select2-selection--multiple {
-                border-radius: 0.5rem; /* Sudut input yang lebih membulat */
-                border-color: #ced4da;
-            }
-            .form-control:focus, .select2-container--bootstrap-5.select2-container--focus .select2-selection--multiple {
-                border-color: #86b7fe; /* Warna fokus yang lebih lembut */
-                box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
-            }
-            /* Custom file input styling */
-            .custom-file-input-wrapper {
-                position: relative;
-                overflow: hidden;
-                display: inline-block;
-                width: 100%;
-            }
-            .custom-file-input-wrapper input[type="file"] {
-                position: absolute;
-                left: 0;
-                top: 0;
-                opacity: 0;
-                cursor: pointer;
-                width: 100%;
-                height: 100%;
-            }
-            .custom-file-input-display {
-                display: flex;
-                align-items: center;
-                border: 1px solid #ced4da;
-                border-radius: 0.5rem;
-                padding: 0.375rem 0.75rem;
-                background-color: #fff;
-                cursor: pointer;
-                transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
-            }
-            .custom-file-input-display:hover {
-                border-color: #86b7fe;
-            }
-            .custom-file-input-display .file-name {
-                flex-grow: 1;
-                margin-left: 0.5rem;
-                color: #6c757d;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-            }
-            .custom-file-input-display .btn-upload {
-                flex-shrink: 0;
-                background-color: #0d6efd;
-                color: #fff;
-                border: none;
-                padding: 0.25rem 0.75rem;
-                border-radius: 0.3rem;
-            }
-            .badge {
-                border-radius: 1rem; /* Badge berbentuk pil */
-                padding: 0.4em 0.7em;
-                font-weight: 500;
-            }
-            .table thead th {
-                background-color: #f1f4f8; /* Latar belakang header tabel yang lebih lembut */
-                color: #495057;
-                font-weight: 600;
-            }
+    @php
+        $me = $availableUsers->firstWhere('id', auth()->id());
+        $candidates = $availableUsers->reject(fn ($u) => $u->id === auth()->id())->values();
 
-            /* ===== Mobile: ubah tabel anggota jadi kartu bertumpuk ===== */
-            @media (max-width: 767.98px) {
-                #selectedMembers thead {
-                    display: none;
-                }
-                #selectedMembers,
-                #selectedMembers tbody,
-                #selectedMembers tr,
-                #selectedMembers td {
-                    display: block;
-                    width: 100%;
-                }
-                #selectedMembers tr {
-                    margin-bottom: 0.75rem;
-                    border: 1px solid #e9ecef;
-                    border-radius: 0.5rem;
-                    padding: 0.35rem 0.75rem;
-                    background-color: #fff;
-                }
-                #selectedMembers tr.table-primary {
-                    border-color: #9ec5fe;
-                    background-color: #f0f6ff;
-                }
-                #selectedMembers td {
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                    gap: 0.75rem;
-                    padding: 0.4rem 0;
-                    border: none;
-                    border-bottom: 1px solid #f1f3f5;
-                }
-                #selectedMembers td:last-child {
-                    border-bottom: none;
-                }
-                #selectedMembers td::before {
-                    content: attr(data-label);
-                    font-weight: 600;
-                    color: #6c757d;
-                    flex-shrink: 0;
-                }
-                /* Tap target lebih besar untuk tombol hapus */
-                #selectedMembers .remove-member {
-                    padding: 0.4rem 0.7rem;
-                }
-            }
+        $selfPakai = $timCounts[$me->id] ?? 0;
+        $selfMaks = $me->jabatan->eselon->maks_honor ?? 0;
+        $selfFull = $selfPakai >= $selfMaks;
+        $selfLabel = $selfFull ? 'Tidak akan menerima honor' : 'Akan menerima honor jika disetujui';
+        $selfHc = $selfFull ? ['fg' => '#5C6B85', 'bg' => '#EDF0F7'] : ['fg' => '#3562E3', 'bg' => '#3562E314'];
 
-            /* ===== Mobile: action bar submit menempel di bawah ===== */
-            @media (max-width: 767.98px) {
-                .form-action-bar {
-                    position: sticky;
-                    bottom: 0;
-                    z-index: 5;
-                    background-color: #fff;
-                    padding: 0.75rem 0;
-                    margin-top: 1rem;
-                    border-top: 1px solid #e9ecef;
-                }
-                .form-action-bar .btn {
-                    flex: 1 1 0;
-                }
-            }
-        </style>
-    @endpush
+        $initialStep = 1;
+        if ($errors->has('nama_tim') || $errors->has('keterangan')) {
+            $initialStep = 1;
+        } elseif ($errors->has('sk_file')) {
+            $initialStep = 2;
+        } elseif ($errors->has('anggota') || $errors->has('anggota.*')) {
+            $initialStep = 3;
+        }
 
-    <div class="container my-4">
-        <div class="card">
-            <div class="card-header">
-                <div class="d-flex justify-content-between align-items-center">
-                    <h5 class="mb-0">Buat Tim Baru</h5>
-                    <a href="{{ route('staff.tim.index') }}" class="btn btn-outline-secondary btn-sm">
-                        <i class="bi bi-arrow-left"></i> Kembali
-                    </a>
+        $oldAnggota = old('anggota', []);
+        $stepLabels = ['Informasi Tim', 'Dokumen SK', 'Anggota', 'Tinjau & Ajukan'];
+    @endphp
+
+    <div style="max-width: 760px; margin: 0 auto;">
+        <form id="wizardForm" action="{{ route('staff.tim.store') }}" method="POST" enctype="multipart/form-data">
+            @csrf
+            <input type="hidden" name="anggota[]" value="{{ auth()->id() }}">
+
+            <div class="flex items-center justify-between gap-12" style="margin-bottom: 18px;">
+                <div>
+                    <h1 class="h1-page">Buat Tim Baru</h1>
+                    <div class="sub-page" id="stepMeta">Langkah {{ $initialStep }} dari 4 — {{ $stepLabels[$initialStep - 1] }}</div>
+                </div>
+                <a href="{{ route('staff.dashboard.index') }}" class="btn btn-secondary" style="height: 36px; padding: 0 14px; font-size: 13px;">Batal</a>
+            </div>
+
+            {{-- Desktop stepper --}}
+            <div class="stepper staff-desktop-only" id="stepper">
+                @foreach ($stepLabels as $i => $label)
+                    <div class="stepper-item" style="flex: {{ $i < 3 ? '1 1 0' : '0 0 auto' }};">
+                        <div class="flex items-center gap-9">
+                            <div class="stepper-circle" data-step-circle="{{ $i + 1 }}">
+                                <span class="stepper-num">{{ $i + 1 }}</span>
+                                <span class="stepper-check">
+                                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+                                </span>
+                            </div>
+                            <div class="stepper-label" data-step-label="{{ $i + 1 }}">{{ $label }}</div>
+                        </div>
+                        @if ($i < 3)
+                            <div class="stepper-line" data-step-line="{{ $i + 1 }}"></div>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+
+            {{-- Mobile progress bar --}}
+            <div class="wizard-progress staff-mobile-only">
+                <div class="wizard-progress-fill" id="wizardProgressFill"></div>
+            </div>
+
+            <div class="card" style="padding: 26px;">
+
+                {{-- STEP 1: Informasi Tim --}}
+                <div class="flex-col gap-18" data-step-panel="1" @if ($initialStep !== 1) hidden @endif>
+                    <div class="flex-col gap-6">
+                        <label for="w_nama" class="field-label">Nama Tim <span class="field-required">*</span></label>
+                        <input id="w_nama" name="nama_tim" type="text" class="input" value="{{ old('nama_tim') }}" placeholder="cth. Tim Penyusunan LAKIP 2026">
+                        <div class="field-hint">Gunakan nama persis seperti yang tertulis pada dokumen SK.</div>
+                        @error('nama_tim') <div class="err-box">{{ $message }}</div> @enderror
+                    </div>
+                    <div class="flex-col gap-6">
+                        <label for="w_ket" class="field-label">Keterangan <span class="field-required">*</span></label>
+                        <textarea id="w_ket" name="keterangan" rows="4" class="textarea" placeholder="Jelaskan singkat tugas dan tujuan tim ini…">{{ old('keterangan') }}</textarea>
+                        @error('keterangan') <div class="err-box">{{ $message }}</div> @enderror
+                    </div>
+                </div>
+
+                {{-- STEP 2: Dokumen SK --}}
+                <div class="flex-col gap-16" data-step-panel="2" @if ($initialStep !== 2) hidden @endif>
+                    <div>
+                        <div class="field-label" style="margin-bottom: 4px;">Dokumen SK Tim <span class="field-required">*</span></div>
+                        <div class="field-hint">Unggah Surat Keputusan pembentukan tim sebagai dasar persetujuan admin.</div>
+                    </div>
+
+                    <label for="w_file" class="dropzone" id="dropzone">
+                        <div class="dropzone-icon">
+                            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="M17 8l-5-5-5 5"></path><path d="M12 3v12"></path></svg>
+                        </div>
+                        <div style="font-size: 14.5px; font-weight: 700; color: var(--ink);">Klik untuk memilih file</div>
+                        <div class="field-hint">Format PDF · maksimal 2 MB</div>
+                    </label>
+
+                    <div class="file-card" id="filePreview" hidden>
+                        <div class="file-card-icon">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><path d="M14 2v6h6"></path></svg>
+                        </div>
+                        <div style="flex: 1; min-width: 0;">
+                            <div style="font-size: 14px; font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;" id="fileName"></div>
+                            <div class="text-success" style="font-size: 12.5px; display: flex; align-items: center; gap: 5px;">
+                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+                                <span id="fileSize"></span> · siap diunggah
+                            </div>
+                        </div>
+                        <label for="w_file" class="btn-secondary" style="height: 34px; padding: 0 13px; font-size: 12.5px; display: flex; align-items: center; border-radius: 10px; cursor: pointer;">Ganti</label>
+                        <button type="button" class="btn-icon" id="fileRemove" aria-label="Hapus file" style="width: 34px; height: 34px;">
+                            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
+                        </button>
+                    </div>
+
+                    <input id="w_file" name="sk_file" type="file" accept="application/pdf" style="display: none;">
+
+                    <div class="err-box" id="fileError" hidden></div>
+                    @error('sk_file') <div class="err-box">{{ $message }}</div> @enderror
+                </div>
+
+                {{-- STEP 3: Anggota --}}
+                <div class="flex-col gap-14" data-step-panel="3" @if ($initialStep !== 3) hidden @endif>
+                    <div class="flex items-center justify-between gap-10 flex-wrap">
+                        <div>
+                            <div class="field-label" style="margin-bottom: 4px;">Pilih Anggota Tim <span class="field-required">*</span></div>
+                            <div class="field-hint">Sebagai pembuat tim, Anda otomatis menjadi anggota.</div>
+                        </div>
+                        <span class="badge-pill badge-accent" id="selectedCount">{{ count($oldAnggota ?: [auth()->id()]) }} anggota dipilih</span>
+                    </div>
+
+                    <div class="flex items-center gap-12" style="padding: 12px 14px; border: 1.5px solid var(--aksen-line); background: var(--aksen-tint); border-radius: 14px;">
+                        <div class="avatar avatar-34 avatar-solid">{{ $me->initials }}</div>
+                        <div style="flex: 1;">
+                            <div style="font-size: 13.5px; font-weight: 700;">{{ $me->name }} <span style="font-weight: 600; color: var(--muted);">(Anda)</span></div>
+                            <div class="text-muted" style="font-size: 12px;">{{ $me->jabatan->name ?? '-' }}</div>
+                        </div>
+                        <span class="badge-pill" style="background: {{ $selfFull ? '#FBF0DC' : '#E4F5EE' }}; color: {{ $selfFull ? '#B96E00' : '#17915F' }};">Kuota {{ $selfPakai }}/{{ $selfMaks }}</span>
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#8B99B3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
+                    </div>
+
+                    <div style="position: relative;">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#8B99B3" stroke-width="2" stroke-linecap="round" style="position: absolute; left: 12px; top: 12px;"><circle cx="11" cy="11" r="7"></circle><path d="m21 21-4.3-4.3"></path></svg>
+                        <input type="text" id="w_member_search" class="input" style="height: 40px; padding-left: 36px;" placeholder="Cari nama atau jabatan…" aria-label="Cari anggota">
+                    </div>
+
+                    <div class="flex-col gap-6" style="max-height: 320px; overflow-y: auto; padding-right: 2px;" id="candidateList">
+                        @forelse ($candidates as $u)
+                            @php
+                                $pakai = $timCounts[$u->id] ?? 0;
+                                $maks = $u->jabatan->eselon->maks_honor ?? 0;
+                                $full = $pakai >= $maks;
+                            @endphp
+                            <label class="check-row" data-name="{{ mb_strtolower($u->name . ' ' . ($u->jabatan->name ?? '')) }}">
+                                <input type="checkbox" name="anggota[]" value="{{ $u->id }}" class="sr-checkbox" data-user-id="{{ $u->id }}" @checked(in_array($u->id, $oldAnggota))>
+                                <span class="check-box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg></span>
+                                <div class="avatar avatar-34">{{ $u->initials }}</div>
+                                <div style="flex: 1; min-width: 0;">
+                                    <div style="font-size: 13.5px; font-weight: 700;">{{ $u->name }}</div>
+                                    <div class="text-muted2" style="font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{ $u->jabatan->name ?? '-' }} · NIP {{ $u->nip }}</div>
+                                </div>
+                                <span class="badge-pill" style="background: {{ $full ? '#FBF0DC' : '#E4F5EE' }}; color: {{ $full ? '#B96E00' : '#17915F' }}; white-space: nowrap;">{{ $full ? 'Kuota penuh ' : 'Kuota ' }}{{ $pakai }}/{{ $maks }}</span>
+                            </label>
+                        @empty
+                            <div style="padding: 24px; text-align: center; color: var(--muted2); font-size: 13.5px;">Tidak ada ASN lain yang terdaftar.</div>
+                        @endforelse
+                        <div style="padding: 24px; text-align: center; color: var(--muted2); font-size: 13.5px;" id="candidatesEmpty" hidden>Tidak ada ASN yang cocok dengan pencarian.</div>
+                    </div>
+
+                    <div class="info-box">
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#8B99B3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0; margin-top: 1px;"><circle cx="12" cy="12" r="9"></circle><path d="M12 16v-4"></path><path d="M12 8h.01"></path></svg>
+                        Anggota berlabel &quot;Kuota penuh&quot; tetap dapat bergabung, namun tidak akan menerima honor dari tim ini.
+                    </div>
+                    @error('anggota') <div class="err-box">{{ $message }}</div> @enderror
+                </div>
+
+                {{-- STEP 4: Tinjau & Ajukan --}}
+                <div class="flex-col gap-18" data-step-panel="4" @if ($initialStep !== 4) hidden @endif>
+                    <div class="review-block">
+                        <div class="review-block-head">
+                            <div style="font-size: 12px; font-weight: 800; letter-spacing: .6px; color: var(--muted2);">INFORMASI TIM</div>
+                            <button type="button" class="btn-link" data-goto="1">Ubah</button>
+                        </div>
+                        <div style="font-size: 15px; font-weight: 700; margin-bottom: 6px;" id="reviewNama"></div>
+                        <div class="text-muted" style="font-size: 13.5px; line-height: 1.6;" id="reviewKet"></div>
+                    </div>
+
+                    <div class="review-block">
+                        <div class="review-block-head">
+                            <div style="font-size: 12px; font-weight: 800; letter-spacing: .6px; color: var(--muted2);">DOKUMEN SK</div>
+                            <button type="button" class="btn-link" data-goto="2">Ubah</button>
+                        </div>
+                        <div class="flex items-center gap-10">
+                            <div class="file-card-icon" style="width: 34px; height: 34px;">
+                                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><path d="M14 2v6h6"></path></svg>
+                            </div>
+                            <div>
+                                <div style="font-size: 13.5px; font-weight: 700;" id="reviewFileName"></div>
+                                <div class="text-muted2" style="font-size: 12px;" id="reviewFileSize"></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="review-block">
+                        <div class="review-block-head">
+                            <div style="font-size: 12px; font-weight: 800; letter-spacing: .6px; color: var(--muted2);" id="reviewMemberCount">ANGGOTA</div>
+                            <button type="button" class="btn-link" data-goto="3">Ubah</button>
+                        </div>
+                        <div class="flex-col gap-8">
+                            <div class="flex items-center gap-10">
+                                <div class="avatar avatar-30 avatar-solid">{{ $me->initials }}</div>
+                                <div style="flex: 1; min-width: 0;">
+                                    <div style="font-size: 13.5px; font-weight: 600;">{{ $me->name }} (Anda)</div>
+                                    <div class="text-muted2" style="font-size: 11.5px;">{{ $me->jabatan->name ?? '-' }}</div>
+                                </div>
+                                <span class="badge-pill" style="background: {{ $selfHc['bg'] }}; color: {{ $selfHc['fg'] }}; white-space: nowrap;">{{ $selfLabel }}</span>
+                            </div>
+                            @foreach ($candidates as $u)
+                                @php
+                                    $pakai = $timCounts[$u->id] ?? 0;
+                                    $maks = $u->jabatan->eselon->maks_honor ?? 0;
+                                    $full = $pakai >= $maks;
+                                    $rLabel = $full ? 'Tidak akan menerima honor' : 'Akan menerima honor jika disetujui';
+                                    $rFg = $full ? '#5C6B85' : '#3562E3';
+                                    $rBg = $full ? '#EDF0F7' : '#3562E314';
+                                @endphp
+                                <div class="flex items-center gap-10" data-review-member="{{ $u->id }}" hidden>
+                                    <div class="avatar avatar-30">{{ $u->initials }}</div>
+                                    <div style="flex: 1; min-width: 0;">
+                                        <div style="font-size: 13.5px; font-weight: 600;">{{ $u->name }}</div>
+                                        <div class="text-muted2" style="font-size: 11.5px;">{{ $u->jabatan->name ?? '-' }}</div>
+                                    </div>
+                                    <span class="badge-pill" style="background: {{ $rBg }}; color: {{ $rFg }}; white-space: nowrap;">{{ $rLabel }}</span>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+
+                    <div class="warn-box">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#B96E00" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0; margin-top: 1px;"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v5l3 3"></path></svg>
+                        Setelah diajukan, tim berstatus <strong>Menunggu Persetujuan</strong> dan akan ditinjau oleh admin. Status honor tiap anggota mengikuti sisa kuota masing-masing.
+                    </div>
+                </div>
+
+                {{-- Footer nav --}}
+                <div class="flex items-center justify-between gap-12" style="margin-top: 26px; padding-top: 20px; border-top: 1px solid var(--border3);">
+                    <button type="button" class="btn btn-secondary" id="btnBack">
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"></path></svg>
+                        Kembali
+                    </button>
+                    <div class="flex items-center gap-14">
+                        <span class="text-muted2" style="font-size: 12.5px;" id="stepHint"></span>
+                        <button type="button" class="btn btn-primary" id="btnNext">
+                            Lanjut
+                            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"></path></svg>
+                        </button>
+                        <button type="submit" class="btn btn-primary" id="btnSubmit" hidden>
+                            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"></path><path d="M22 2 11 13"></path></svg>
+                            Ajukan Tim
+                        </button>
+                    </div>
                 </div>
             </div>
-            <div class="card-body">
-                <form action="{{ route('staff.tim.store') }}" method="POST" enctype="multipart/form-data">
-                    @csrf
-
-                    <!-- Nama Tim -->
-                    <div class="mb-3">
-                        <label for="nama_tim" class="form-label">Nama Tim <span class="text-danger">*</span></label>
-                        <input type="text" class="form-control @error('nama_tim') is-invalid @enderror"
-                            id="nama_tim" name="nama_tim" value="{{ old('nama_tim') }}" required>
-                        @error('nama_tim')
-                            <div class="invalid-feedback">{{ $message }}</div>
-                        @enderror
-                    </div>
-
-                    <!-- Keterangan -->
-                    <div class="mb-3">
-                        <label for="keterangan" class="form-label">Keterangan <span class="text-danger">*</span></label>
-                        <textarea class="form-control @error('keterangan') is-invalid @enderror" id="keterangan" name="keterangan"
-                            rows="3" required>{{ old('keterangan') }}</textarea>
-                        @error('keterangan')
-                            <div class="invalid-feedback">{{ $message }}</div>
-                        @enderror
-                    </div>
-
-                    <!-- Upload SK (Customized) -->
-                    <div class="mb-3">
-                        <label for="sk_file" class="form-label">Upload SK (PDF) <span
-                                class="text-danger">*</span></label>
-                        <div class="custom-file-input-wrapper">
-                            <input type="file" class="form-control @error('sk_file') is-invalid @enderror" id="sk_file"
-                                name="sk_file" accept="application/pdf" required>
-                            <div class="custom-file-input-display">
-                                <span class="btn-upload"><i class="bi bi-upload"></i> Pilih File</span>
-                                <span class="file-name" id="sk_file_name">Tidak ada file dipilih</span>
-                            </div>
-                        </div>
-                        @error('sk_file')
-                            <div class="invalid-feedback">{{ $message }}</div>
-                        @enderror
-                    </div>
-
-                    <!-- Pilih Anggota -->
-                    <div class="mb-4">
-                        <label class="form-label">Pilih Anggota Tim <span class="text-danger">*</span></label>
-                        {{-- Input tersembunyi untuk user yang sedang login --}}
-                        <input type="hidden" name="anggota[]" value="{{ Auth::id() }}" id="loggedInUserHiddenInput">
-                        <select class="form-control select2-multiple @error('anggota') is-invalid @enderror"
-                            name="anggota[]" id="anggota" multiple="multiple">
-                            @foreach ($availableUsers as $user)
-                                <option value="{{ $user->id }}" data-nip="{{ $user->nip }}"
-                                    data-jabatan="{{ $user->jabatan->name }}"
-                                    data-tim-count="{{ $timCounts[$user->id] ?? 0 }}"
-                                    data-maks-honor="{{ $user->jabatan->eselon->maks_honor }}"
-                                    @if ($user->id == Auth::id()) selected disabled data-is-logged-in="true" @endif>
-                                    {{ $user->name }} @if ($user->id == Auth::id()) (Anda) @endif
-                                </option>
-                            @endforeach
-                        </select>
-                        @error('anggota')
-                            <div class="invalid-feedback">{{ $message }}</div>
-                        @enderror
-                    </div>
-
-                    <!-- Preview Anggota Terpilih -->
-                    <div class="mb-4">
-                        <div class="card">
-                            <div class="card-header">
-                                <h6 class="mb-0">Anggota Terpilih</h6>
-                            </div>
-                            <div class="card-body p-0">
-                                <div class="table-responsive">
-                                    <table class="table table-hover mb-0" id="selectedMembers">
-                                        <thead>
-                                            <tr>
-                                                <th>Nama</th>
-                                                <th>NIP</th>
-                                                <th>Jabatan</th>
-                                                <th>Status Honor</th>
-                                                <th>Aksi</th> {{-- Tambah kolom Aksi --}}
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <!-- Diisi oleh JavaScript -->
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Tombol Submit -->
-                    <div class="form-action-bar d-flex justify-content-end gap-2">
-                        <a href="{{ route('staff.tim.index') }}" class="btn btn-secondary">Batal</a>
-                        <button type="submit" class="btn btn-primary">Tambahkan Tim</button>
-                    </div>
-                </form>
-            </div>
-        </div>
+        </form>
     </div>
 
     @push('scripts')
         <script>
-            $(document).ready(function() {
-                // Inisialisasi Select2
-                $('.select2-multiple').select2({
-                    theme: 'bootstrap-5',
-                    width: '100%',
-                    placeholder: 'Pilih anggota tim',
-                    allowClear: true,
-                    templateSelection: function (data, container) {
-                        // Jika opsi adalah user yang sedang login, tambahkan kelas untuk menonaktifkan penghapusan
-                        if ($(data.element).data('is-logged-in')) {
-                            $(container).addClass('select2-selection__choice--disabled');
-                        }
-                        return data.text;
-                    }
-                });
+            (function () {
+                const form = document.getElementById('wizardForm');
+                const panels = form.querySelectorAll('[data-step-panel]');
+                const stepperCircles = form.querySelectorAll('[data-step-circle]');
+                const stepperLabels = form.querySelectorAll('[data-step-label]');
+                const stepperLines = form.querySelectorAll('[data-step-line]');
+                const progressFill = document.getElementById('wizardProgressFill');
+                const stepMeta = document.getElementById('stepMeta');
+                const stepLabels = @json($stepLabels);
+                const btnBack = document.getElementById('btnBack');
+                const btnNext = document.getElementById('btnNext');
+                const btnSubmit = document.getElementById('btnSubmit');
+                const stepHint = document.getElementById('stepHint');
 
-                // Fungsi untuk memperbarui tabel preview
-                function updateSelectedMembersTable() {
-                    let tbody = $('#selectedMembers tbody');
-                    tbody.empty();
+                const namaInput = document.getElementById('w_nama');
+                const ketInput = document.getElementById('w_ket');
+                const fileInput = document.getElementById('w_file');
+                const dropzone = document.getElementById('dropzone');
+                const filePreview = document.getElementById('filePreview');
+                const fileNameEl = document.getElementById('fileName');
+                const fileSizeEl = document.getElementById('fileSize');
+                const fileError = document.getElementById('fileError');
+                const fileRemove = document.getElementById('fileRemove');
 
-                    // Dapatkan ID user yang sedang login
-                    const loggedInUserId = {{ Auth::id() }};
+                const memberSearch = document.getElementById('w_member_search');
+                const candidateList = document.getElementById('candidateList');
+                const candidatesEmpty = document.getElementById('candidatesEmpty');
+                const selectedCount = document.getElementById('selectedCount');
 
-                    // Ambil semua opsi yang terpilih, termasuk yang disabled
-                    let selectedOptions = $('#anggota').find(':selected');
+                let currentStep = {{ $initialStep }};
 
-                    // Tambahkan opsi user yang sedang login jika belum ada di selectedOptions
-                    let loggedInUserOptionExists = false;
-                    selectedOptions.each(function() {
-                        if ($(this).val() == loggedInUserId) {
-                            loggedInUserOptionExists = true;
-                            return false; // break loop
-                        }
-                    });
-
-                    if (!loggedInUserOptionExists) {
-                        // Jika user yang login tidak ada di selectedOptions (misal karena Select2 clear all),
-                        // tambahkan secara manual dari opsi yang disabled
-                        let loggedInUserOption = $('#anggota option[data-is-logged-in="true"]');
-                        if (loggedInUserOption.length) {
-                            selectedOptions = selectedOptions.add(loggedInUserOption);
-                        }
-                    }
-
-
-                    selectedOptions.each(function() {
-                        let option = $(this);
-                        let userId = option.val();
-                        let timCount = option.data('tim-count');
-                        let maksHonor = option.data('maks-honor');
-                        let isLoggedInUser = option.data('is-logged-in');
-
-                        let badgeClass = 'bg-success';
-
-                        if (maksHonor === 0) {
-                            badgeClass = 'bg-secondary';
-                        } else if (timCount < maksHonor) {
-                            badgeClass = 'bg-success';
-                        } else {
-                            badgeClass = 'bg-danger';
-                        }
-
-                        if (maksHonor > 0 && timCount >= maksHonor * 0.8 && timCount < maksHonor) {
-                            badgeClass = 'bg-warning';
-                        }
-
-                        let actionButton = '';
-                        let rowClass = '';
-                        if (isLoggedInUser) {
-                            actionButton = '<span class="text-muted">Tidak dapat dihapus</span>';
-                            rowClass = 'table-primary'; // Menandai baris user yang login
-                        } else {
-                            actionButton = `<button type="button" class="btn btn-sm btn-danger remove-member" data-id="${userId}"><i class="bi bi-trash"></i></button>`;
-                        }
-
-                        tbody.append(`
-                            <tr class="${rowClass}">
-                                <td data-label="Nama">${option.text()}</td>
-                                <td data-label="NIP" class="col-nip">${option.data('nip')}</td>
-                                <td data-label="Jabatan">${option.data('jabatan')}</td>
-                                <td data-label="Status Honor">
-                                    <span class="badge ${badgeClass}">${timCount}/${maksHonor}</span>
-                                </td>
-                                <td data-label="Aksi">${actionButton}</td>
-                            </tr>
-                        `);
-                    });
+                function formatSize(bytes) {
+                    return bytes > 1024 * 1024 ? (bytes / 1048576).toFixed(1) + ' MB' : Math.max(1, Math.round(bytes / 1024)) + ' KB';
                 }
 
-                // Panggil fungsi update saat Select2 berubah
-                $('#anggota').on('change', function() {
-                    updateSelectedMembersTable();
+                function validateStep1() {
+                    return namaInput.value.trim().length > 0 && ketInput.value.trim().length > 0;
+                }
+
+                function validateStep2() {
+                    return fileInput.files.length > 0;
+                }
+
+                function isValid(step) {
+                    if (step === 1) return validateStep1();
+                    if (step === 2) return validateStep2();
+                    return true;
+                }
+
+                function updateStepper() {
+                    stepperCircles.forEach(c => {
+                        const n = Number(c.dataset.stepCircle);
+                        c.classList.toggle('done', n < currentStep);
+                        c.classList.toggle('current', n === currentStep);
+                    });
+                    stepperLabels.forEach(l => {
+                        const n = Number(l.dataset.stepLabel);
+                        l.classList.toggle('done', n < currentStep);
+                        l.classList.toggle('current', n === currentStep);
+                    });
+                    stepperLines.forEach(line => {
+                        const n = Number(line.dataset.stepLine);
+                        line.classList.toggle('done', n < currentStep);
+                    });
+                    if (progressFill) progressFill.style.width = (currentStep / 4 * 100) + '%';
+                }
+
+                function syncReview() {
+                    document.getElementById('reviewNama').textContent = namaInput.value.trim();
+                    document.getElementById('reviewKet').textContent = ketInput.value.trim();
+                    const f = fileInput.files[0];
+                    document.getElementById('reviewFileName').textContent = f ? f.name : '';
+                    document.getElementById('reviewFileSize').textContent = f ? formatSize(f.size) : '';
+
+                    const checked = candidateList.querySelectorAll('input[type=checkbox]:checked');
+                    const checkedIds = new Set(Array.from(checked).map(c => c.dataset.userId));
+                    form.querySelectorAll('[data-review-member]').forEach(row => {
+                        row.hidden = !checkedIds.has(row.dataset.reviewMember);
+                    });
+                    document.getElementById('reviewMemberCount').textContent = 'ANGGOTA (' + (checked.length + 1) + ')';
+                }
+
+                function updateHint(step) {
+                    const valid = isValid(step);
+                    stepHint.textContent = valid ? '' : (
+                        step === 1 ? 'Isi nama tim dan keterangan untuk melanjutkan' :
+                        step === 2 ? 'Unggah dokumen SK untuk melanjutkan' : ''
+                    );
+                    btnNext.disabled = !valid;
+                }
+
+                function goToStep(step) {
+                    currentStep = step;
+                    panels.forEach(p => { p.hidden = Number(p.dataset.stepPanel) !== step; });
+                    stepMeta.textContent = 'Langkah ' + step + ' dari 4 — ' + stepLabels[step - 1];
+                    updateStepper();
+                    btnBack.style.visibility = step > 1 ? '' : 'hidden';
+                    btnNext.hidden = step === 4;
+                    btnSubmit.hidden = step !== 4;
+                    if (step === 4) syncReview();
+                    updateHint(step);
+                    window.scrollTo(0, 0);
+                }
+
+                namaInput.addEventListener('input', () => updateHint(1));
+                ketInput.addEventListener('input', () => updateHint(1));
+
+                function resetFileUi() {
+                    dropzone.hidden = false;
+                    filePreview.hidden = true;
+                }
+
+                fileInput.addEventListener('change', () => {
+                    const f = fileInput.files[0];
+                    fileError.hidden = true;
+                    fileError.textContent = '';
+
+                    if (!f) { resetFileUi(); updateHint(2); return; }
+
+                    if (f.type !== 'application/pdf') {
+                        fileError.textContent = 'Format file harus PDF.';
+                        fileError.hidden = false;
+                        fileInput.value = '';
+                        resetFileUi();
+                        updateHint(2);
+                        return;
+                    }
+                    if (f.size > 2 * 1024 * 1024) {
+                        fileError.textContent = 'Ukuran file melebihi 2 MB.';
+                        fileError.hidden = false;
+                        fileInput.value = '';
+                        resetFileUi();
+                        updateHint(2);
+                        return;
+                    }
+
+                    fileNameEl.textContent = f.name;
+                    fileSizeEl.textContent = formatSize(f.size);
+                    dropzone.hidden = true;
+                    filePreview.hidden = false;
+                    updateHint(2);
                 });
 
-                // Panggil fungsi update saat halaman dimuat untuk menampilkan user yang login
-                updateSelectedMembersTable();
-
-                // Handle penghapusan anggota dari tabel preview
-                $(document).on('click', '.remove-member', function() {
-                    const userIdToRemove = $(this).data('id');
-                    const select2Instance = $('#anggota').select2();
-
-                    // Dapatkan nilai saat ini dari Select2
-                    let currentSelections = select2Instance.val();
-
-                    // Filter array untuk menghapus user yang dipilih
-                    currentSelections = currentSelections.filter(id => id != userIdToRemove);
-
-                    // Setel nilai Select2 yang baru
-                    select2Instance.val(currentSelections).trigger('change');
+                fileRemove.addEventListener('click', () => {
+                    fileInput.value = '';
+                    resetFileUi();
+                    updateHint(2);
                 });
 
-
-                // Handle custom file input display
-                $('#sk_file').on('change', function() {
-                    const fileName = $(this).val().split('\\').pop();
-                    $('#sk_file_name').text(fileName || 'Tidak ada file dipilih');
+                memberSearch.addEventListener('input', () => {
+                    const q = memberSearch.value.trim().toLowerCase();
+                    let visible = 0;
+                    candidateList.querySelectorAll('.check-row').forEach(row => {
+                        const show = !q || row.dataset.name.includes(q);
+                        row.hidden = !show;
+                        if (show) visible++;
+                    });
+                    candidatesEmpty.hidden = visible > 0;
                 });
-            });
+
+                candidateList.addEventListener('change', (e) => {
+                    const cb = e.target.closest('input[type=checkbox]');
+                    if (!cb) return;
+                    cb.closest('.check-row').classList.toggle('checked', cb.checked);
+                    const count = candidateList.querySelectorAll('input[type=checkbox]:checked').length + 1;
+                    selectedCount.textContent = count + ' anggota dipilih';
+                });
+
+                btnBack.addEventListener('click', () => { if (currentStep > 1) goToStep(currentStep - 1); });
+                btnNext.addEventListener('click', () => { if (isValid(currentStep) && currentStep < 4) goToStep(currentStep + 1); });
+
+                form.querySelectorAll('[data-goto]').forEach(btn => {
+                    btn.addEventListener('click', () => goToStep(Number(btn.dataset.goto)));
+                });
+
+                form.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' && currentStep < 4 && e.target.tagName !== 'TEXTAREA') {
+                        e.preventDefault();
+                    }
+                });
+
+                // Reflect any pre-checked members (validation round-trip) in the UI.
+                candidateList.querySelectorAll('input[type=checkbox]:checked').forEach(cb => cb.closest('.check-row').classList.add('checked'));
+
+                goToStep(currentStep);
+            })();
         </script>
     @endpush
 </x-staff-layout>

--- a/resources/views/staff/tim/index.blade.php
+++ b/resources/views/staff/tim/index.blade.php
@@ -1,262 +1,173 @@
 <x-staff-layout>
-    <div class="container my-5">
-        <!-- Header Section -->
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <h3 class="fw-bold text-primary mb-0">Riwayat Tim Anda</h3>
-            <a href="{{ route('staff.tim.create') }}" class="btn btn-primary shadow-sm">
-                <i class="bi bi-plus-lg me-2"></i> Buat Tim Baru
-            </a>
-        </div>
+    @php
+        $statusMeta = [
+            'approved' => ['label' => 'Disetujui', 'fg' => '#17915F', 'bg' => '#E4F5EE'],
+            'pending'  => ['label' => 'Menunggu Persetujuan', 'fg' => '#B96E00', 'bg' => '#FBF0DC'],
+            'rejected' => ['label' => 'Ditolak', 'fg' => '#D14343', 'bg' => '#FBEAEA'],
+        ];
+        $honorColor = [
+            \App\Services\HonorService::DIBAYAR                => ['fg' => '#17915F', 'bg' => '#E4F5EE'],
+            \App\Services\HonorService::TIDAK_DIBAYAR           => ['fg' => '#5C6B85', 'bg' => '#EDF0F7'],
+            \App\Services\HonorService::PREDIKSI_DIBAYAR        => ['fg' => '#3562E3', 'bg' => '#3562E314'],
+            \App\Services\HonorService::PREDIKSI_TIDAK_DIBAYAR  => ['fg' => '#5C6B85', 'bg' => '#EDF0F7'],
+        ];
+    @endphp
 
-        <!-- User Profile Card -->
-        <div class="card shadow-sm border-0 mb-4">
-            <div class="card-body py-3">
-                <div class="d-flex align-items-center">
-                    <div class="flex-shrink-0 me-3">
-                        <div class="rounded-circle bg-primary text-white d-flex align-items-center justify-content-center fs-5 fw-bold"
-                            style="width: 50px; height: 50px;">
-                            {{ strtoupper(substr(Auth::user()->name, 0, 1)) }}
-                        </div>
-                    </div>
-                    <div class="flex-grow-1">
-                        <h5 class="card-title mb-0 fw-semibold">{{ Auth::user()->name }}</h5>
-                        <p class="card-text text-muted small mb-0">NIP. {{ Auth::user()->nip }}</p>
-                    </div>
+    <div class="flex-col gap-20">
+
+        @if (session('success'))
+            <section class="card success-panel">
+                <div class="success-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
                 </div>
+                <h2 style="margin: 0; font-size: 22px; font-weight: 800;">Tim berhasil diajukan</h2>
+                <p style="margin: 0; font-size: 14px; color: var(--muted); line-height: 1.6; max-width: 420px;">
+                    @if (session('teamName'))
+                        <strong>{{ session('teamName') }}</strong>
+                    @else
+                        Tim Anda
+                    @endif
+                    kini berstatus <span style="font-weight: 700; color: var(--warning);">Menunggu Persetujuan</span>.
+                    Anda akan melihat hasil tinjauan admin di halaman ini.
+                </p>
+                <div class="flex gap-10 flex-wrap" style="margin-top: 18px; justify-content: center;">
+                    <a href="{{ route('staff.dashboard.index') }}" class="btn btn-secondary">Ke Beranda</a>
+                </div>
+            </section>
+        @endif
+
+        <div class="flex items-center justify-between gap-16 flex-wrap">
+            <div>
+                <h1 class="h1-page">Riwayat Tim <span style="color: var(--muted2); font-weight: 700;">(PTATK)</span></h1>
+                <div class="sub-page">Rekap keikutsertaan tim dan status honorarium Anda per tahun anggaran.</div>
+            </div>
+            <div role="tablist" aria-label="Tahun anggaran" class="year-tabs">
+                @foreach ($tahunList as $y)
+                    <a href="{{ route('staff.tim.index', ['tahun' => $y]) }}" role="tab" class="year-tab {{ (int) $y === $tahun ? 'active' : '' }}">{{ $y }}</a>
+                @endforeach
             </div>
         </div>
 
-        <!-- Filter Tahun Anggaran Card -->
-        <div class="card shadow-sm border-0 mb-4">
-            <div class="card-body py-3">
-                <div class="row g-2 align-items-center">
-                    <div class="col-auto">
-                        <label for="tahunFilter" class="col-form-label text-muted">Filter Tahun Anggaran:</label>
+        <section class="card flex items-center gap-20 flex-wrap" style="padding: 18px 22px;">
+            <div style="flex: 1 1 240px; min-width: 220px;">
+                <div style="font-size: 12px; font-weight: 800; letter-spacing: .8px; color: var(--muted2); margin-bottom: 10px;">KUOTA HONOR TAHUN {{ $tahun }}</div>
+                @if ($maksHonor > 0)
+                    <div class="flex gap-6">
+                        @for ($i = 0; $i < $maksHonor; $i++)
+                            <div class="slot-bar slot-bar-sm {{ $i < $ringkasan['jumlah_dibayar'] ? 'filled' : '' }}"></div>
+                        @endfor
                     </div>
-                    <div class="col-auto">
-                        <select class="form-select form-select-sm" id="tahunFilter">
-                            @foreach ($tahunList as $th)
-                                <option value="{{ $th }}" {{ $tahun == $th ? 'selected' : '' }}>
-                                    Tahun {{ $th }}
-                                </option>
+                @else
+                    <div class="text-muted" style="font-size: 13px;">Tidak ada informasi kuota.</div>
+                @endif
+            </div>
+            <div class="flex gap-16" style="gap: 26px; flex-wrap: wrap;">
+                <div><div style="font-size: 20px; font-weight: 800;">{{ $ringkasan['jumlah_dibayar'] }}<span style="font-size: 13px; color: var(--muted2); font-weight: 600;">/{{ $maksHonor }}</span></div><div class="text-muted2" style="font-size: 12px;">Honor dibayar</div></div>
+                <div><div style="font-size: 20px; font-weight: 800;">{{ $tims->count() }}</div><div class="text-muted2" style="font-size: 12px;">Total tim</div></div>
+                <div><div style="font-size: 20px; font-weight: 800; color: var(--success);">Rp {{ number_format($ringkasan['total_honor'], 0, ',', '.') }}</div><div class="text-muted2" style="font-size: 12px;">Honor diterima</div></div>
+            </div>
+        </section>
+
+        {{-- Desktop table --}}
+        <section class="card staff-desktop-only" style="overflow: hidden; flex-direction: column;">
+            <div class="ptatk-table-head">
+                <div>NAMA TIM</div><div>DIBUAT</div><div>STATUS TIM</div><div>HONOR ANDA</div><div></div>
+            </div>
+            @forelse ($tims as $tim)
+                @php
+                    $sm = $statusMeta[$tim->status];
+                    $mine = $statusHonorPerTim[$user->id][$tim->id] ?? null;
+                    $hc = $mine ? $honorColor[$mine['status']] : null;
+                @endphp
+                <div class="ptatk-row-wrap">
+                    <button type="button" class="ptatk-row-head" data-toggle-target="ptatk-body-{{ $tim->id }}" aria-expanded="false">
+                        <div>
+                            <div style="font-size: 14px; font-weight: 700;">{{ $tim->nama_tim }}</div>
+                            <div class="text-muted2" style="font-size: 12px; font-weight: 500; margin-top: 2px;">{{ $tim->users->count() }} anggota</div>
+                        </div>
+                        <div class="text-muted" style="font-size: 13px;">{{ $tim->created_at->locale('id')->translatedFormat('d M Y') }}</div>
+                        <div><span class="badge-pill" style="background: {{ $sm['bg'] }}; color: {{ $sm['fg'] }};">{{ $sm['label'] }}</span></div>
+                        <div>
+                            @if ($mine)
+                                <span class="badge-pill" style="background: {{ $hc['bg'] }}; color: {{ $hc['fg'] }};">{{ $mine['label'] }}</span>
+                            @endif
+                        </div>
+                        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="#8B99B3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"></path></svg>
+                    </button>
+                    <div id="ptatk-body-{{ $tim->id }}" class="ptatk-row-body" hidden>
+                        <p style="margin: 10px 0 14px; font-size: 13.5px; color: var(--muted); line-height: 1.6;">{{ $tim->keterangan }}</p>
+                        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 8px;">
+                            @foreach ($tim->users as $anggota)
+                                @php
+                                    $mm = $statusHonorPerTim[$anggota->id][$tim->id] ?? null;
+                                    $mc = $mm ? $honorColor[$mm['status']] : null;
+                                @endphp
+                                <div class="flex items-center gap-10" style="padding: 10px 12px; background: #fff; border: 1px solid var(--border3); border-radius: 12px;">
+                                    <div class="avatar avatar-30">{{ $anggota->initials }}</div>
+                                    <div style="flex: 1; min-width: 0;">
+                                        <div style="font-size: 13px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{ $anggota->name }}</div>
+                                        <div class="text-muted2" style="font-size: 11.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{ $anggota->jabatan->name ?? '-' }}</div>
+                                    </div>
+                                    @if ($mm)
+                                        <span class="badge-pill" style="background: {{ $mc['bg'] }}; color: {{ $mc['fg'] }}; white-space: nowrap; font-size: 11px; padding: 4px 9px;">{{ $mm['label'] }}</span>
+                                    @endif
+                                </div>
                             @endforeach
-                        </select>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Progress and Team History Section -->
-        <div class="card shadow-sm border-0">
-            <div class="card-body">
-                <!-- Honor Progress Card -->
-                <div class="card bg-light border-0 mb-4">
-                    <div class="card-body py-3">
-                        <div class="d-flex justify-content-between align-items-center mb-2">
-                            <h6 class="mb-0 fw-semibold text-secondary">Progress Penerimaan Honor</h6>
-                            <span
-                                class="badge rounded-pill {{ $progress >= 100 ? 'bg-warning text-dark' : 'bg-success' }} py-2 px-3">
-                                {{ $approvedTimCount[$user->id] ?? 0 }}/{{ $maksHonor }}
-                                @if ($progress >= 100)
-                                    <i class="bi bi-exclamation-circle-fill ms-1"></i>
-                                @else
-                                    <i class="bi bi-check-circle-fill ms-1"></i>
-                                @endif
-                            </span>
-                        </div>
-                        <div class="progress" style="height: 8px;">
-                            <div class="progress-bar {{ $progress >= 100 ? 'bg-warning' : 'bg-success' }}"
-                                role="progressbar" style="width: {{ $progress }}%"
-                                aria-valuenow="{{ $progress }}" aria-valuemin="0" aria-valuemax="100">
-                            </div>
                         </div>
                     </div>
                 </div>
+            @empty
+                <div style="padding: 36px; text-align: center; color: var(--muted2); font-size: 14px;">Belum ada data tim yang tersedia.</div>
+            @endforelse
+        </section>
 
-                <!-- Team History Table -->
-                <div class="table-responsive">
-                    <table class="table table-hover align-middle">
-                        <thead class="table-light">
-                            <tr>
-                                <th scope="col">Nama Tim</th>
-                                <th scope="col" class="text-center">Terima Honor</th>
-                                <th scope="col">Status Tim</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @forelse($tims ?? [] as $tim)
-                                <tr data-bs-toggle="collapse" data-bs-target="#detail-{{ $tim->id }}"
-                                    class="accordion-toggle cursor-pointer">
-                                    <td>
-                                        <div class="d-flex align-items-center">
-                                            <i class="bi bi-people-fill text-primary me-2 fs-5"></i>
-                                            <span class="fw-medium">{{ $tim->nama_tim }}</span>
-                                        </div>
-                                    </td>
-                                    <td class="text-center">
-                                        @php
-                                            $honorStatus = $statusHonorPerTim[$user->id][$tim->id] ?? 'Tidak diketahui';
-                                            $iconClass = '';
-
-                                            if (
-                                                $honorStatus === 'Honor Diterima' ||
-                                                $honorStatus === 'Akan menerima honor jika disetujui'
-                                            ) {
-                                                $iconClass = 'text-success';
-                                            } elseif (
-                                                $honorStatus === 'Tidak menerima honor lagi' ||
-                                                $honorStatus === 'Tidak akan menerima honor'
-                                            ) {
-                                                $iconClass = 'text-danger';
-                                            } else {
-                                                $iconClass = 'text-warning';
-                                            }
-                                        @endphp
-
-                                        @if ($honorStatus === 'Honor Diterima')
-                                            <i class="bi bi-check-circle-fill fs-5 {{ $iconClass }}"
-                                                data-bs-toggle="tooltip" data-bs-placement="top"
-                                                title="Honor Diterima"></i>
-                                        @elseif ($honorStatus === 'Tidak menerima honor lagi')
-                                            <i class="bi bi-x-circle-fill fs-5 {{ $iconClass }}"
-                                                data-bs-toggle="tooltip" data-bs-placement="top"
-                                                title="Tidak Menerima Honor Lagi"></i>
-                                        @else
-                                            <i class="bi bi-question-circle-fill fs-5 {{ $iconClass }}"
-                                                data-bs-toggle="tooltip" data-bs-placement="top"
-                                                title="Status Honor Tidak Diketahui"></i>
-                                        @endif
-                                        {{-- Caption teks untuk layar sentuh (tooltip tidak jalan di mobile) --}}
-                                        <span class="d-block d-md-none small {{ $iconClass }} mt-1">
-                                            {{ $honorStatus }}
-                                        </span>
-                                    </td>
-                                    <td>
-                                        <span
-                                            class="badge rounded-pill px-3 py-2 {{ $tim->status === 'approved' ? 'bg-success' : ($tim->status === 'pending' ? 'bg-warning text-dark' : 'bg-danger') }}">
-                                            {{ ucfirst($tim->status) }}
-                                        </span>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td colspan="3" class="p-0 border-0">
-                                        <div id="detail-{{ $tim->id }}" class="collapse bg-light border-top">
-                                            <div class="card card-body m-3 p-4">
-                                                <div class="row">
-                                                    <div class="col-md-6 mb-3 mb-md-0">
-                                                        <h6 class="card-title fw-bold text-primary mb-3">Detail Tim</h6>
-                                                        <p class="mb-2 small"><strong>Nama Tim:</strong> <span
-                                                                class="text-muted">{{ $tim->nama_tim }}</span></p>
-                                                        <p class="mb-2 small"><strong>Tanggal Dibuat:</strong> <span
-                                                                class="text-muted">{{ $tim->created_at->format('d M Y H:i') }}</span>
-                                                        </p>
-                                                        <p class="mb-0 small"><strong>Status Tim:</strong>
-                                                            <span
-                                                                class="badge rounded-pill {{ $tim->status === 'approved' ? 'bg-success' : ($tim->status === 'pending' ? 'bg-warning text-dark' : 'bg-danger') }}">
-                                                                {{ ucfirst($tim->status) }}
-                                                            </span>
-                                                        </p>
-                                                    </div>
-                                                    <div class="col-md-6">
-                                                        <h6 class="card-title fw-bold text-primary mb-3">Anggota Tim
-                                                        </h6>
-                                                        <div class="table-responsive">
-                                                            <table class="table table-sm table-borderless mb-0">
-                                                                <thead class="table-secondary">
-                                                                    <tr>
-                                                                        <th scope="col" class="small">Nama</th>
-                                                                        <th scope="col" class="small">Jabatan</th>
-                                                                        <th scope="col" class="small">Status Honor
-                                                                        </th>
-                                                                    </tr>
-                                                                </thead>
-                                                                <tbody>
-                                                                    @foreach ($tim->users as $anggota)
-                                                                        <tr>
-                                                                            <td class="small">{{ $anggota->name }}
-                                                                            </td>
-                                                                            <td class="small">
-                                                                                {{ $anggota->jabatan->name }}</td>
-                                                                            <td class="small">
-                                                                                <span
-                                                                                    class="badge bg-secondary-subtle text-secondary">
-                                                                                    {{ $statusHonorPerTim[$anggota->id][$tim->id] ?? 'Tidak diketahui' }}
-                                                                                </span>
-                                                                            </td>
-                                                                        </tr>
-                                                                    @endforeach
-                                                                </tbody>
-                                                            </table>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </td>
-                                </tr>
-                            @empty
-                                <tr>
-                                    <td colspan="3" class="text-center text-muted py-4">
-                                        <i class="bi bi-info-circle me-2"></i> Belum ada data tim yang tersedia.
-                                    </td>
-                                </tr>
-                            @endforelse
-                        </tbody>
-                    </table>
-                </div>
-            </div>
+        {{-- Mobile cards --}}
+        <div class="flex-col gap-10 staff-mobile-only">
+            @forelse ($tims as $tim)
+                @php
+                    $sm = $statusMeta[$tim->status];
+                    $mine = $statusHonorPerTim[$user->id][$tim->id] ?? null;
+                    $hc = $mine ? $honorColor[$mine['status']] : null;
+                @endphp
+                <article class="card card-sm">
+                    <button type="button" style="padding: 14px 16px; width: 100%; text-align: left; border: none; background: transparent; cursor: pointer; font-family: inherit;" data-toggle-target="ptatk-mbody-{{ $tim->id }}" aria-expanded="false">
+                        <div class="flex justify-between items-center gap-10">
+                            <div style="font-size: 14.5px; font-weight: 700;">{{ $tim->nama_tim }}</div>
+                            <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="#8B99B3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0;"><path d="m6 9 6 6 6-6"></path></svg>
+                        </div>
+                        <div class="text-muted2" style="font-size: 12px; margin: 4px 0 10px;">{{ $tim->users->count() }} anggota · {{ $tim->created_at->locale('id')->translatedFormat('d M Y') }}</div>
+                        <div class="flex gap-6 flex-wrap">
+                            <span class="badge-pill" style="background: {{ $sm['bg'] }}; color: {{ $sm['fg'] }};">{{ $sm['label'] }}</span>
+                            @if ($mine)
+                                <span class="badge-pill" style="background: {{ $hc['bg'] }}; color: {{ $hc['fg'] }};">{{ $mine['label'] }}</span>
+                            @endif
+                        </div>
+                    </button>
+                    <div id="ptatk-mbody-{{ $tim->id }}" class="team-card-body" hidden>
+                        <p style="margin: 0 0 12px; font-size: 13px; color: var(--muted); line-height: 1.6;">{{ $tim->keterangan }}</p>
+                        <div class="flex-col gap-8">
+                            @foreach ($tim->users as $anggota)
+                                @php
+                                    $mm = $statusHonorPerTim[$anggota->id][$tim->id] ?? null;
+                                    $mc = $mm ? $honorColor[$mm['status']] : null;
+                                @endphp
+                                <div class="flex items-center gap-10">
+                                    <div class="avatar avatar-30">{{ $anggota->initials }}</div>
+                                    <div style="flex: 1; min-width: 0;">
+                                        <div style="font-size: 13px; font-weight: 600;">{{ $anggota->name }}</div>
+                                        <div class="text-muted2" style="font-size: 11.5px;">{{ $anggota->jabatan->name ?? '-' }}</div>
+                                    </div>
+                                    @if ($mm)
+                                        <span class="badge-pill" style="background: {{ $mc['bg'] }}; color: {{ $mc['fg'] }}; white-space: nowrap; font-size: 10.5px; padding: 4px 8px;">{{ $mm['label'] }}</span>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                </article>
+            @empty
+                <div class="card" style="padding: 36px; text-align: center; color: var(--muted2); font-size: 14px;">Belum ada data tim yang tersedia.</div>
+            @endforelse
         </div>
     </div>
-
-    @push('styles')
-        <style>
-            .cursor-pointer {
-                cursor: pointer;
-            }
-
-            .accordion-toggle:hover {
-                background-color: var(--bs-table-hover-bg);
-            }
-
-            .table-hover>tbody>tr.accordion-toggle:hover>td {
-                background-color: var(--bs-table-hover-bg);
-            }
-
-            .table-hover>tbody>tr.accordion-toggle:hover {
-                --bs-table-hover-bg: #f8f9fa;
-                /* Light gray on hover */
-            }
-
-            .card {
-                border-radius: 0.75rem;
-                /* Slightly more rounded corners */
-            }
-
-            .btn {
-                border-radius: 0.5rem;
-            }
-
-            .form-select {
-                border-radius: 0.5rem;
-            }
-
-            .badge {
-                font-weight: 600;
-            }
-        </style>
-    @endpush
-
-    @push('scripts')
-        <script>
-            document.getElementById('tahunFilter').addEventListener('change', function() {
-                window.location.href = '{{ route('staff.tim.index') }}?tahun=' + this.value;
-            });
-
-            // Initialize tooltips
-            var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
-            var tooltipList = tooltipTriggerList.map(function(tooltipTriggerEl) {
-                return new bootstrap.Tooltip(tooltipTriggerEl)
-            })
-        </script>
-    @endpush
 </x-staff-layout>


### PR DESCRIPTION
…v, 4-step wizard

Implement complete redesign of staff-facing pages (Login, Beranda, PTATK, Buat Tim, Profil) using custom CSS design system (Plus Jakarta Sans, --aksen #3562E3, card shadows). Drop Bootstrap/jQuery/Select2 for staff pages; use vanilla JS for pixel-accurate interactivity.

New assets:
- public/css/staff-app.css: design tokens, shared components (buttons, cards, badges, dropzone, stepper/progress, bottom nav)
- public/js/staff-app.js: generic expand/collapse handler for cards and table rows
- resources/views/staff/partials/: profile-card, profile-honor

Page changes:
- Login: card-based design with password show/hide toggle, error banner for failed login
- Navbar: desktop topbar with nav pills / mobile topbar + fixed bottom nav (Beranda/FAB/PTATK)
- Beranda: hero card with slot bar, search + filter chips, expandable team cards
- PTATK: year-tab buttons, kuota summary bar, expandable desktop table / mobile cards
- Buat Tim: real 4-step wizard (info → SK upload → members → review) with client-side validation, "Ubah" jump-back links, proper success panel on submission
- Profil: two-column desktop / stacked mobile layout

Backend:
- User::initials accessor for avatar initials
- StaffController: scope Beranda to current tahun anggaran, pass full $ringkasan to PTATK, flash team name on creation, restructure buildStatusMap to include raw status code